### PR TITLE
feat: implement Stellar ledger data downloader and unit tests

### DIFF
--- a/astroml/ingestion/stellar_ledger.py
+++ b/astroml/ingestion/stellar_ledger.py
@@ -1,0 +1,146 @@
+"""Module for downloading historical Stellar ledger data."""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import pathlib
+from typing import Any, Optional
+
+import aiohttp
+from astroml.ingestion.config import StreamConfig
+
+logger = logging.getLogger("astroml.ingestion.stellar_ledger")
+
+
+class StellarLedgerDownloader:
+    """Downloader for historical Stellar ledger data.
+
+    Supports downloading a range of ledgers, saving them as JSON or XDR,
+    and handles pagination and retries.
+    """
+
+    def __init__(self, config: Optional[StreamConfig] = None) -> None:
+        self._config = config or StreamConfig()
+        self._session: Optional[aiohttp.ClientSession] = None
+
+    async def __aenter__(self) -> StellarLedgerDownloader:
+        self._session = aiohttp.ClientSession()
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+        if self._session:
+            await self._session.close()
+
+    async def _fetch_with_retry(self, url: str) -> dict[str, Any]:
+        """Fetch a URL with exponential backoff retry logic."""
+        retry_count = 0
+        while True:
+            try:
+                async with self._session.get(url) as response:
+                    if response.status == 200:
+                        return await response.json()
+                    elif response.status == 429:
+                        logger.warning("Rate limit hit, retrying...")
+                    elif response.status >= 500:
+                        logger.warning("Server error %d, retrying...", response.status)
+                    else:
+                        response.raise_for_status()
+            except (aiohttp.ClientError, asyncio.TimeoutError) as e:
+                logger.warning("Network error: %s, retrying...", e)
+
+            retry_count += 1
+            if self._config.max_retries > 0 and retry_count > self._config.max_retries:
+                raise Exception(f"Max retries exceeded for {url}")
+
+            delay = min(
+                self._config.reconnect_base_seconds * (2 ** (retry_count - 1)),
+                self._config.reconnect_max_seconds,
+            )
+            await asyncio.sleep(delay)
+
+    async def download_range(
+        self,
+        start_ledger: int,
+        end_ledger: int,
+        output_dir: str = "data/ledgers",
+        format: str = "json",
+    ) -> None:
+        """Download a range of ledgers and save them to disk.
+
+        Args:
+            start_ledger: Starting ledger sequence (inclusive).
+            end_ledger: Ending ledger sequence (inclusive).
+            output_dir: Directory to save the ledger data.
+            format: Output format ("json" or "xdr"). Currently only "json" is fully supported via Horizon.
+        """
+        if format not in ("json", "xdr"):
+            raise ValueError(f"Unsupported format: {format}")
+
+        path = pathlib.Path(output_dir)
+        path.mkdir(parents=True, exist_ok=True)
+
+        current_ledger = start_ledger
+        cursor = str(start_ledger - 1)
+
+        while current_ledger <= end_ledger:
+            url = f"{self._config.horizon_url}/ledgers?cursor={cursor}&limit=200&order=asc"
+            logger.info("Fetching ledgers from cursor %s", cursor)
+            
+            data = await self._fetch_with_retry(url)
+            records = data.get("_embedded", {}).get("records", [])
+
+            if not records:
+                logger.info("No more ledgers found.")
+                break
+
+            for record in records:
+                seq = record["sequence"]
+                if seq > end_ledger:
+                    break
+                
+                if format == "json":
+                    file_path = path / f"ledger_{seq}.json"
+                    file_path.write_text(json.dumps(record, indent=2))
+                elif format == "xdr":
+                    # Horizon provides header_xdr and other XDR fields in the JSON response
+                    # For a pure XDR download, we'd typically use ledger archives, 
+                    # but here we save what Horizon provides.
+                    file_path = path / f"ledger_{seq}.xdr"
+                    file_path.write_text(record.get("header_xdr", ""))
+
+                cursor = record["paging_token"]
+                current_ledger = seq + 1
+
+            if current_ledger > end_ledger:
+                break
+
+        logger.info("Download complete. Ledgers %d to %d (or last available) saved to %s", 
+                    start_ledger, min(current_ledger - 1, end_ledger), output_dir)
+
+
+async def main():
+    """Simple CLI for the downloader."""
+    import argparse
+    import sys
+
+    parser = argparse.ArgumentParser(description="Stellar Ledger Downloader")
+    parser.add_argument("--start", type=int, required=True, help="Start ledger sequence")
+    parser.add_argument("--end", type=int, required=True, help="End ledger sequence")
+    parser.add_argument("--output", default="data/ledgers", help="Output directory")
+    parser.add_argument("--format", choices=["json", "xdr"], default="json", help="Output format")
+    
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO)
+    
+    async with StellarLedgerDownloader() as downloader:
+        try:
+            await downloader.download_range(args.start, args.end, args.output, args.format)
+        except Exception as e:
+            logger.error("Download failed: %s", e)
+            sys.exit(1)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/test_stellar_ledger.py
+++ b/tests/test_stellar_ledger.py
@@ -1,0 +1,113 @@
+import json
+import pytest
+import aiohttp
+from unittest.mock import AsyncMock, patch
+from astroml.ingestion.stellar_ledger import StellarLedgerDownloader
+from astroml.ingestion.config import StreamConfig
+
+@pytest.fixture
+def mock_config():
+    return StreamConfig(
+        horizon_url="https://horizon-testnet.stellar.org",
+        reconnect_base_seconds=0.1,
+        reconnect_max_seconds=0.2,
+        max_retries=2
+    )
+
+@pytest.mark.asyncio
+async def test_download_range_success(mock_config, tmp_path):
+    downloader = StellarLedgerDownloader(config=mock_config)
+    output_dir = tmp_path / "ledgers"
+    
+    mock_response_data = {
+        "_embedded": {
+            "records": [
+                {"sequence": 100, "paging_token": "100_0", "header_xdr": "AAAAA..."},
+                {"sequence": 101, "paging_token": "101_0", "header_xdr": "BBBBB..."}
+            ]
+        }
+    }
+    
+    with patch("aiohttp.ClientSession.get") as mock_get:
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json.return_value = mock_response_data
+        mock_get.return_value.__aenter__.return_value = mock_resp
+        
+        async with downloader:
+            await downloader.download_range(100, 101, output_dir=str(output_dir))
+            
+    assert (output_dir / "ledger_100.json").exists()
+    assert (output_dir / "ledger_101.json").exists()
+    
+    ledger_100 = json.loads((output_dir / "ledger_100.json").read_text())
+    assert ledger_100["sequence"] == 100
+
+@pytest.mark.asyncio
+async def test_download_range_pagination(mock_config, tmp_path):
+    downloader = StellarLedgerDownloader(config=mock_config)
+    output_dir = tmp_path / "ledgers"
+    
+    # Page 1: Ledger 100
+    mock_response_1 = {
+        "_embedded": {
+            "records": [{"sequence": 100, "paging_token": "100_0"}]
+        }
+    }
+    # Page 2: Ledger 101
+    mock_response_2 = {
+        "_embedded": {
+            "records": [{"sequence": 101, "paging_token": "101_0"}]
+        }
+    }
+    
+    with patch("aiohttp.ClientSession.get") as mock_get:
+        mock_resp_1 = AsyncMock()
+        mock_resp_1.status = 200
+        mock_resp_1.json.return_value = mock_response_1
+        
+        mock_resp_2 = AsyncMock()
+        mock_resp_2.status = 200
+        mock_resp_2.json.return_value = mock_response_2
+        
+        mock_get.return_value.__aenter__.side_effect = [mock_resp_1, mock_resp_2]
+        
+        async with downloader:
+            await downloader.download_range(100, 101, output_dir=str(output_dir))
+            
+    assert (output_dir / "ledger_100.json").exists()
+    assert (output_dir / "ledger_101.json").exists()
+
+@pytest.mark.asyncio
+async def test_download_range_retry(mock_config, tmp_path):
+    downloader = StellarLedgerDownloader(config=mock_config)
+    output_dir = tmp_path / "ledgers"
+    
+    mock_response_data = {
+        "_embedded": {
+            "records": [{"sequence": 100, "paging_token": "100_0"}]
+        }
+    }
+    
+    with patch("aiohttp.ClientSession.get") as mock_get:
+        # Fail once with 429, then succeed
+        mock_resp_fail = AsyncMock()
+        mock_resp_fail.status = 429
+        
+        mock_resp_success = AsyncMock()
+        mock_resp_success.status = 200
+        mock_resp_success.json.return_value = mock_response_data
+        
+        mock_get.return_value.__aenter__.side_effect = [mock_resp_fail, mock_resp_success]
+        
+        async with downloader:
+            await downloader.download_range(100, 100, output_dir=str(output_dir))
+            
+    assert (output_dir / "ledger_100.json").exists()
+
+@pytest.mark.asyncio
+async def test_download_range_invalid_format(mock_config, tmp_path):
+    downloader = StellarLedgerDownloader(config=mock_config)
+    with pytest.raises(ValueError, match="Unsupported format"):
+        async with downloader:
+            await downloader.download_range(100, 101, format="invalid")


### PR DESCRIPTION
Closes #1

---

# Pull Request: Stellar Ledger Data Downloader

## Overview

This PR implements a new Python module, `StellarLedgerDownloader`, designed to fetch historical ledger data from the Stellar network via the Horizon API. This module is essential for data analysis and machine learning tasks that require a local corpus of Stellar ledger history.

## Key Features

- **Range-Based Downloads**: Efficiently fetches ledgers between a specified start and end sequence.
- **Multiple Formats**: Supports saving data in both JSON (full ledger details) and XDR (using Horizon's `header_xdr`).
- **Robust Pagination**: Automatically handles Horizon paging tokens to traverse large ledger ranges seamlessly.
- **Exponential Backoff**: Built-in retry logic to handle transient network errors and Horizon rate limits (HTTP 429).
- **CLI Utility**: Includes a command-line interface for quick ad-hoc data collection.

## Implementation Details

- **Module**: `stellar_ledger.py`
- **Tests**: `test_stellar_ledger.py`
- **Dependencies**: Uses `aiohttp` for asynchronous requests, integrating with the existing `StreamConfig` system.

## Performance & Reliability

- Uses asynchronous I/O to maintain high throughput.
- Implements configurable retry logic (base delay, max delay, and max retries).

## How to Verify

Run the newly added unit tests to ensure all core functionalities (range fetching, pagination, and retry logic) are working as expected:

```bash
PYTHONPATH=. pytest tests/test_stellar_ledger.py