### PR TITLE
Closed #75 [Feature] Synthetic Fraud Pattern Injector

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,25 @@ python -m astroml.graph.build_snapshot --window 30d
 
 ---
 
+
+## 🧪 Synthetic Fraud Pattern Injection
+
+Create benchmark datasets by injecting controlled fraud structures into a clean ledger copy:
+
+```bash
+python -m astroml.ingestion.synthetic_fraud_injector \
+  --input data/clean_ledger.jsonl \
+  --output data/ledger_with_fraud.jsonl \
+  --summary outputs/fraud_injection_summary.json \
+  --sybil-clusters 3 \
+  --sybil-cluster-size 8 \
+  --wash-loops 2 \
+  --wash-loop-size 5
+```
+
+The injector appends transactions tagged with `synthetic_fraud=true` and `fraud_pattern` (`sybil_cluster` or `wash_trading_loop`) for downstream benchmarking.
+
+---
 ## 🤖 Train Baseline GCN
 
 ```bash

--- a/astroml/ingestion/synthetic_fraud_injector.py
+++ b/astroml/ingestion/synthetic_fraud_injector.py
@@ -1,0 +1,316 @@
+from __future__ import annotations
+
+"""Synthetic fraud pattern injector for ledger benchmarking.
+
+This module can copy a "clean" transaction ledger and append synthetic fraud
+patterns for controlled benchmarking experiments.
+
+Supported patterns:
+- Sybil clusters: one controller account fans out to many coordinated identities.
+- Wash-trading loops: a set of accounts repeatedly sends value in a closed loop.
+
+Input and output files support either:
+- JSON array of transaction objects
+- JSON lines (JSONL), one transaction object per line
+"""
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+import argparse
+import json
+import pathlib
+import random
+from typing import Any
+
+
+DEFAULT_SOURCE_FIELD = "source_account"
+DEFAULT_DEST_FIELD = "destination_account"
+DEFAULT_AMOUNT_FIELD = "amount"
+DEFAULT_TIMESTAMP_FIELD = "created_at"
+
+
+@dataclass(frozen=True)
+class SybilConfig:
+    clusters: int = 2
+    cluster_size: int = 5
+    tx_per_member: int = 3
+    base_amount: float = 25.0
+
+
+@dataclass(frozen=True)
+class WashLoopConfig:
+    loops: int = 2
+    loop_size: int = 4
+    rounds: int = 5
+    base_amount: float = 100.0
+
+
+@dataclass(frozen=True)
+class InjectionSummary:
+    original_transactions: int
+    injected_transactions: int
+    total_transactions: int
+    sybil_transactions: int
+    wash_loop_transactions: int
+
+
+def _load_transactions(path: pathlib.Path) -> tuple[list[dict[str, Any]], str]:
+    raw = path.read_text(encoding="utf-8").strip()
+    if not raw:
+        return [], "jsonl"
+
+    if raw.startswith("["):
+        data = json.loads(raw)
+        if not isinstance(data, list):
+            raise ValueError("JSON input must be an array of transaction objects")
+        return [dict(item) for item in data], "json"
+
+    records: list[dict[str, Any]] = []
+    for line in raw.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        parsed = json.loads(line)
+        if not isinstance(parsed, dict):
+            raise ValueError("Each JSONL line must be a transaction object")
+        records.append(parsed)
+    return records, "jsonl"
+
+
+def _write_transactions(path: pathlib.Path, txs: list[dict[str, Any]], fmt: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if fmt == "json":
+        path.write_text(json.dumps(txs, indent=2), encoding="utf-8")
+        return
+
+    with path.open("w", encoding="utf-8") as f:
+        for tx in txs:
+            f.write(json.dumps(tx) + "\n")
+
+
+def _max_timestamp(transactions: list[dict[str, Any]], timestamp_field: str) -> datetime:
+    latest: datetime | None = None
+    for tx in transactions:
+        value = tx.get(timestamp_field)
+        if not isinstance(value, str):
+            continue
+        try:
+            ts = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            continue
+        if latest is None or ts > latest:
+            latest = ts
+
+    return latest or datetime.now(timezone.utc)
+
+
+def _new_tx(
+    tx_id: int,
+    source: str,
+    destination: str,
+    amount: float,
+    timestamp: datetime,
+    source_field: str,
+    dest_field: str,
+    amount_field: str,
+    timestamp_field: str,
+    pattern_type: str,
+    metadata: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        "synthetic_tx_id": tx_id,
+        source_field: source,
+        dest_field: destination,
+        amount_field: round(amount, 7),
+        timestamp_field: timestamp.isoformat().replace("+00:00", "Z"),
+        "synthetic_fraud": True,
+        "fraud_pattern": pattern_type,
+        "fraud_metadata": metadata,
+    }
+
+
+def inject_synthetic_fraud(
+    transactions: list[dict[str, Any]],
+    *,
+    seed: int = 7,
+    sybil: SybilConfig = SybilConfig(),
+    wash: WashLoopConfig = WashLoopConfig(),
+    source_field: str = DEFAULT_SOURCE_FIELD,
+    dest_field: str = DEFAULT_DEST_FIELD,
+    amount_field: str = DEFAULT_AMOUNT_FIELD,
+    timestamp_field: str = DEFAULT_TIMESTAMP_FIELD,
+) -> tuple[list[dict[str, Any]], InjectionSummary]:
+    """Append synthetic fraud patterns and return augmented ledger + summary."""
+    rng = random.Random(seed)
+    augmented = [dict(tx) for tx in transactions]
+
+    start_ts = _max_timestamp(augmented, timestamp_field)
+    current_ts = start_ts
+    next_id = 1
+
+    sybil_injected = 0
+    for cluster_idx in range(sybil.clusters):
+        controller = f"sybil_controller_{cluster_idx}"
+        members = [f"sybil_{cluster_idx}_{i}" for i in range(sybil.cluster_size)]
+
+        for member in members:
+            for tx_idx in range(sybil.tx_per_member):
+                current_ts += timedelta(seconds=1)
+                amount = sybil.base_amount * (1 + rng.uniform(-0.2, 0.2))
+                augmented.append(
+                    _new_tx(
+                        tx_id=next_id,
+                        source=controller if tx_idx % 2 == 0 else member,
+                        destination=member if tx_idx % 2 == 0 else controller,
+                        amount=amount,
+                        timestamp=current_ts,
+                        source_field=source_field,
+                        dest_field=dest_field,
+                        amount_field=amount_field,
+                        timestamp_field=timestamp_field,
+                        pattern_type="sybil_cluster",
+                        metadata={
+                            "cluster": cluster_idx,
+                            "controller": controller,
+                            "member": member,
+                        },
+                    )
+                )
+                next_id += 1
+                sybil_injected += 1
+
+    wash_injected = 0
+    for loop_idx in range(wash.loops):
+        loop_accounts = [f"wash_{loop_idx}_{i}" for i in range(wash.loop_size)]
+        for round_idx in range(wash.rounds):
+            for i, sender in enumerate(loop_accounts):
+                receiver = loop_accounts[(i + 1) % len(loop_accounts)]
+                current_ts += timedelta(seconds=1)
+                amount = wash.base_amount * (1 + rng.uniform(-0.03, 0.03))
+                augmented.append(
+                    _new_tx(
+                        tx_id=next_id,
+                        source=sender,
+                        destination=receiver,
+                        amount=amount,
+                        timestamp=current_ts,
+                        source_field=source_field,
+                        dest_field=dest_field,
+                        amount_field=amount_field,
+                        timestamp_field=timestamp_field,
+                        pattern_type="wash_trading_loop",
+                        metadata={
+                            "loop": loop_idx,
+                            "round": round_idx,
+                        },
+                    )
+                )
+                next_id += 1
+                wash_injected += 1
+
+    summary = InjectionSummary(
+        original_transactions=len(transactions),
+        injected_transactions=sybil_injected + wash_injected,
+        total_transactions=len(augmented),
+        sybil_transactions=sybil_injected,
+        wash_loop_transactions=wash_injected,
+    )
+    return augmented, summary
+
+
+def run_injection(
+    *,
+    input_path: str,
+    output_path: str,
+    summary_path: str | None,
+    seed: int,
+    sybil: SybilConfig,
+    wash: WashLoopConfig,
+    source_field: str,
+    dest_field: str,
+    amount_field: str,
+    timestamp_field: str,
+) -> InjectionSummary:
+    """Load input ledger, inject fraud patterns, and save output ledger."""
+    in_path = pathlib.Path(input_path)
+    out_path = pathlib.Path(output_path)
+    txs, fmt = _load_transactions(in_path)
+
+    augmented, summary = inject_synthetic_fraud(
+        txs,
+        seed=seed,
+        sybil=sybil,
+        wash=wash,
+        source_field=source_field,
+        dest_field=dest_field,
+        amount_field=amount_field,
+        timestamp_field=timestamp_field,
+    )
+
+    _write_transactions(out_path, augmented, fmt)
+
+    if summary_path:
+        pathlib.Path(summary_path).write_text(
+            json.dumps(summary.__dict__, indent=2),
+            encoding="utf-8",
+        )
+
+    return summary
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Inject synthetic fraud patterns into a ledger copy")
+    parser.add_argument("--input", required=True, help="Path to clean ledger file (JSON or JSONL)")
+    parser.add_argument("--output", required=True, help="Path to augmented output ledger")
+    parser.add_argument("--summary", default=None, help="Optional path for JSON summary output")
+    parser.add_argument("--seed", type=int, default=7, help="RNG seed for deterministic generation")
+
+    parser.add_argument("--sybil-clusters", type=int, default=2)
+    parser.add_argument("--sybil-cluster-size", type=int, default=5)
+    parser.add_argument("--sybil-tx-per-member", type=int, default=3)
+    parser.add_argument("--sybil-base-amount", type=float, default=25.0)
+
+    parser.add_argument("--wash-loops", type=int, default=2)
+    parser.add_argument("--wash-loop-size", type=int, default=4)
+    parser.add_argument("--wash-rounds", type=int, default=5)
+    parser.add_argument("--wash-base-amount", type=float, default=100.0)
+
+    parser.add_argument("--source-field", default=DEFAULT_SOURCE_FIELD)
+    parser.add_argument("--destination-field", default=DEFAULT_DEST_FIELD)
+    parser.add_argument("--amount-field", default=DEFAULT_AMOUNT_FIELD)
+    parser.add_argument("--timestamp-field", default=DEFAULT_TIMESTAMP_FIELD)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    summary = run_injection(
+        input_path=args.input,
+        output_path=args.output,
+        summary_path=args.summary,
+        seed=args.seed,
+        sybil=SybilConfig(
+            clusters=args.sybil_clusters,
+            cluster_size=args.sybil_cluster_size,
+            tx_per_member=args.sybil_tx_per_member,
+            base_amount=args.sybil_base_amount,
+        ),
+        wash=WashLoopConfig(
+            loops=args.wash_loops,
+            loop_size=args.wash_loop_size,
+            rounds=args.wash_rounds,
+            base_amount=args.wash_base_amount,
+        ),
+        source_field=args.source_field,
+        dest_field=args.destination_field,
+        amount_field=args.amount_field,
+        timestamp_field=args.timestamp_field,
+    )
+    print(json.dumps(summary.__dict__, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_synthetic_fraud_injector.py
+++ b/tests/test_synthetic_fraud_injector.py
@@ -1,0 +1,82 @@
+import json
+
+from astroml.ingestion.synthetic_fraud_injector import (
+    SybilConfig,
+    WashLoopConfig,
+    inject_synthetic_fraud,
+    run_injection,
+)
+
+
+def test_inject_synthetic_fraud_counts_and_markers():
+    base = [
+        {
+            "source_account": "A",
+            "destination_account": "B",
+            "amount": 10,
+            "created_at": "2025-01-01T00:00:00Z",
+        }
+    ]
+
+    out, summary = inject_synthetic_fraud(
+        base,
+        seed=123,
+        sybil=SybilConfig(clusters=1, cluster_size=2, tx_per_member=2, base_amount=15.0),
+        wash=WashLoopConfig(loops=1, loop_size=3, rounds=2, base_amount=50.0),
+    )
+
+    assert summary.original_transactions == 1
+    assert summary.sybil_transactions == 4  # 1 * 2 * 2
+    assert summary.wash_loop_transactions == 6  # 1 * 3 * 2
+    assert summary.injected_transactions == 10
+    assert summary.total_transactions == 11
+
+    injected = [tx for tx in out if tx.get("synthetic_fraud")]
+    assert len(injected) == 10
+    assert {tx["fraud_pattern"] for tx in injected} == {"sybil_cluster", "wash_trading_loop"}
+
+
+def test_run_injection_keeps_jsonl_format_and_writes_summary(tmp_path):
+    input_path = tmp_path / "ledger.jsonl"
+    output_path = tmp_path / "ledger_augmented.jsonl"
+    summary_path = tmp_path / "summary.json"
+
+    input_path.write_text(
+        "\n".join(
+            [
+                json.dumps({
+                    "source_account": "S1",
+                    "destination_account": "D1",
+                    "amount": 1.2,
+                    "created_at": "2025-01-02T03:04:05Z",
+                }),
+                json.dumps({
+                    "source_account": "S2",
+                    "destination_account": "D2",
+                    "amount": 2.3,
+                    "created_at": "2025-01-02T03:04:06Z",
+                }),
+            ]
+        ) + "\n",
+        encoding="utf-8",
+    )
+
+    summary = run_injection(
+        input_path=str(input_path),
+        output_path=str(output_path),
+        summary_path=str(summary_path),
+        seed=7,
+        sybil=SybilConfig(clusters=1, cluster_size=1, tx_per_member=1, base_amount=9.0),
+        wash=WashLoopConfig(loops=1, loop_size=2, rounds=1, base_amount=10.0),
+        source_field="source_account",
+        dest_field="destination_account",
+        amount_field="amount",
+        timestamp_field="created_at",
+    )
+
+    out_lines = output_path.read_text(encoding="utf-8").strip().splitlines()
+    assert len(out_lines) == summary.total_transactions
+    assert len(out_lines) == 5  # 2 originals + (1 sybil + 2 wash)
+
+    written_summary = json.loads(summary_path.read_text(encoding="utf-8"))
+    assert written_summary["injected_transactions"] == 3


### PR DESCRIPTION
Closes #75

---

### Motivation

- Provide a reproducible way to plant controlled Sybil clusters and wash-trading loops into clean ledger copies so benchmarking and detection experiments can run on realistic, labeled adversarial patterns.
- Enable both programmatic use and a simple CLI to create augmented datasets while preserving input format (JSON vs JSONL) and attaching machine-readable fraud labels for downstream pipelines.

### Description

- Add new module `astroml.ingestion.synthetic_fraud_injector` that implements deterministic, seed-based generation of two fraud motifs: Sybil clusters and wash-trading loops, with tunable size/amount/rounds parameters and field mapping options.  
- Preserve input format by supporting JSON arrays and JSONL (one object per line) and write augmented output in the same format.  
- Tag injected transactions with `synthetic_fraud`, `fraud_pattern`, `fraud_metadata`, and emit an `InjectionSummary` with counts for original, injected, sybil, and wash-loop transactions; provide a `run_injection` API and a small CLI wrapper.  
- Update `README.md` with usage example and add focused unit tests in `tests/test_synthetic_fraud_injector.py` that validate counts, labels, format preservation, and summary output.

### Testing

- Ran the new unit tests with: `PYENV_VERSION=3.12.12 python -m pytest -q tests/test_synthetic_fraud_injector.py`.  
- Test outcome: `2 passed` (both tests in `tests/test_synthetic_fraud_injector.py` succeeded).  
- Note: initial attempts to run `pytest` using the environment default failed due to a pyenv local version mismatch, but tests passed when invoked with the working interpreter as shown above.
