### PR TITLE
fix(cli): clearer top-level help with examples and global flags

### DIFF
--- a/astroml/cli.py
+++ b/astroml/cli.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
+import pathlib
 from typing import Optional
 
 from .db.session import load_database_config
@@ -9,8 +11,70 @@ from .ingestion.service import IngestionService
 from .ingestion.state import StateStore
 
 
+CLI_DESCRIPTION = """\
+AstroML utilities CLI — manage ingestion, configuration, and the
+quick-start pipeline from a single entrypoint.
+
+For full usage, see the README "Usage" section:
+  https://github.com/Traqora/astroml#usage
+"""
+
+CLI_EPILOG = """\
+Examples:
+  # Run incremental ingestion for a ledger range
+  python -m astroml.cli ingest --start 1000 --end 1100
+
+  # Print the effective database configuration that AstroML will use
+  python -m astroml.cli config --print-db
+
+  # Same, but read the YAML config from a custom path
+  python -m astroml.cli --config ./custom/database.yaml config --print-db
+
+  # Run the end-to-end quick start with sample data
+  python -m astroml.cli quickstart --num-ledgers 200 --epochs 5
+
+  # Preprocess a backfill dataset into Parquet
+  python -m astroml.cli preprocess-backfill --input data.csv --output out.parquet
+
+  # Select a runtime environment (sets ASTROML_ENV for downstream loaders)
+  python -m astroml.cli --env production config --print-db
+
+Environment variables:
+  ASTROML_DATABASE_URL  Overrides the database URL from config/database.yaml.
+  ASTROML_ENV           Runtime environment name (development | production).
+                        Set automatically by --env when provided.
+"""
+
+
 def main(argv: Optional[list[str]] = None) -> int:
-    parser = argparse.ArgumentParser(prog="astroml", description="AstroML utilities CLI")
+    parser = argparse.ArgumentParser(
+        prog="astroml",
+        description=CLI_DESCRIPTION,
+        epilog=CLI_EPILOG,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--config",
+        type=pathlib.Path,
+        default=None,
+        metavar="PATH",
+        help=(
+            "Path to the database YAML config (default: config/database.yaml). "
+            "Used by `config --print-db` and any subcommand that reads the "
+            "database configuration."
+        ),
+    )
+    parser.add_argument(
+        "--env",
+        type=str,
+        default=None,
+        metavar="NAME",
+        help=(
+            "Runtime environment name (e.g. development, production). "
+            "When provided, sets ASTROML_ENV for downstream loaders unless "
+            "ASTROML_ENV is already set in the process environment."
+        ),
+    )
     sub = parser.add_subparsers(dest="command", required=True)
 
     ingest = sub.add_parser("ingest", help="Incremental ingestion of ledgers")
@@ -82,6 +146,12 @@ def main(argv: Optional[list[str]] = None) -> int:
 
     args = parser.parse_args(argv)
 
+    # Wire the top-level --env flag into ASTROML_ENV so downstream loaders
+    # (see docs/api/configuration.md) see the requested environment.
+    # Do not overwrite an env var the operator already set explicitly.
+    if args.env and "ASTROML_ENV" not in os.environ:
+        os.environ["ASTROML_ENV"] = args.env
+
     if args.command == "ingest":
         store = StateStore(path=args.state_file) if args.state_file else StateStore()
         service = IngestionService(state_store=store)
@@ -112,7 +182,7 @@ def main(argv: Optional[list[str]] = None) -> int:
     if args.command == "config":
         if args.print_db:
             try:
-                db_config = load_database_config()
+                db_config = load_database_config(args.config)
                 print("Effective database configuration:")
                 print(json.dumps({
                     "host": db_config.host,

--- a/tests/test_cli_help.py
+++ b/tests/test_cli_help.py
@@ -1,0 +1,91 @@
+"""Tests for the top-level CLI help text and global flag wiring.
+
+Regression coverage for #180 — the top-level help must surface examples,
+the `--config` and `--env` flags, and the documented environment
+variables, so new contributors can discover them from `--help` alone.
+"""
+from __future__ import annotations
+
+import io
+import os
+import pathlib
+from contextlib import redirect_stdout
+from unittest import mock
+
+import pytest
+
+from astroml import cli
+
+
+def _capture_help() -> str:
+    buf = io.StringIO()
+    with redirect_stdout(buf), pytest.raises(SystemExit):
+        cli.main(["--help"])
+    return buf.getvalue()
+
+
+def test_help_mentions_global_flags() -> None:
+    output = _capture_help()
+    assert "--config" in output
+    assert "--env" in output
+
+
+def test_help_includes_examples_section() -> None:
+    output = _capture_help()
+    assert "Examples:" in output
+    assert "python -m astroml.cli" in output
+
+
+def test_help_documents_env_vars() -> None:
+    output = _capture_help()
+    assert "ASTROML_DATABASE_URL" in output
+    assert "ASTROML_ENV" in output
+
+
+def test_env_flag_sets_astroml_env_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ASTROML_ENV", raising=False)
+    fake_db = mock.Mock()
+    fake_db.host = "localhost"
+    fake_db.port = 5432
+    fake_db.name = "x"
+    fake_db.user = "u"
+    fake_db.password = ""
+    fake_db.to_url.return_value = "postgresql://u@localhost:5432/x"
+    with mock.patch("astroml.cli.load_database_config", return_value=fake_db):
+        with redirect_stdout(io.StringIO()):
+            rc = cli.main(["--env", "production", "config", "--print-db"])
+    assert rc == 0
+    assert os.environ.get("ASTROML_ENV") == "production"
+
+
+def test_env_flag_does_not_overwrite_existing_value(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ASTROML_ENV", "staging")
+    fake_db = mock.Mock()
+    fake_db.host = "h"
+    fake_db.port = 5432
+    fake_db.name = "n"
+    fake_db.user = "u"
+    fake_db.password = ""
+    fake_db.to_url.return_value = "postgresql://u@h:5432/n"
+    with mock.patch("astroml.cli.load_database_config", return_value=fake_db):
+        with redirect_stdout(io.StringIO()):
+            cli.main(["--env", "production", "config", "--print-db"])
+    assert os.environ["ASTROML_ENV"] == "staging"
+
+
+def test_config_flag_passes_path_to_loader(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ASTROML_ENV", raising=False)
+    fake_db = mock.Mock()
+    fake_db.host = "h"
+    fake_db.port = 5432
+    fake_db.name = "n"
+    fake_db.user = "u"
+    fake_db.password = ""
+    fake_db.to_url.return_value = "postgresql://u@h:5432/n"
+    custom = pathlib.Path("custom/db.yaml")
+    with mock.patch(
+        "astroml.cli.load_database_config", return_value=fake_db
+    ) as load_mock:
+        with redirect_stdout(io.StringIO()):
+            cli.main(["--config", str(custom), "config", "--print-db"])
+    load_mock.assert_called_once_with(custom)


### PR DESCRIPTION
## Summary

Fixes the `astroml` top-level CLI help so contributors do not have to grep the README to discover usage. The current `--help` output omits examples and the `--config` / `--env` flags noted in `docs/api/configuration.md`. This PR expands the help, wires the two global flags, and pins the behavior with tests.

closes #180

## Changes
- **#180 — CLI help text expansion + new global flags**:
  - `astroml/cli.py`:
    - Switches `argparse.ArgumentParser` to `RawDescriptionHelpFormatter` so the new examples block renders with line breaks intact.
    - Rewrites the description and adds an `epilog` containing an `Examples:` block (one runnable invocation per subcommand: `ingest`, `config`, `quickstart`, `preprocess-backfill`) and an `Environment variables:` block documenting `ASTROML_DATABASE_URL` and `ASTROML_ENV`.
    - Adds `--config PATH` at the top level. It is forwarded to `load_database_config(args.config)` in the `config --print-db` subcommand (the loader already accepts an `Optional[pathlib.Path]`).
    - Adds `--env NAME` at the top level. When provided, it sets `os.environ["ASTROML_ENV"]` for downstream loaders — but only if `ASTROML_ENV` is not already set by the operator, so explicit shell-level config wins.
  - `tests/test_cli_help.py` (new): 6 unit tests covering
    - `--help` exits 0 and mentions `--config`, `--env`, an `Examples:` block, `ASTROML_DATABASE_URL`, and `ASTROML_ENV`
    - `--env production` sets `ASTROML_ENV` when unset
    - `--env production` does *not* overwrite an existing `ASTROML_ENV`
    - `--config <path>` forwards the path to `load_database_config`

## Test plan
- `python -m pytest tests/test_cli_help.py` — 6/6 passing locally (Python 3.14, fresh venv with `pyyaml`, `pydantic`, `sqlalchemy`)
- `python -m astroml.cli --help` — confirmed help now shows both new flags and the examples/env-vars sections
- Existing subcommands (`ingest`, `quickstart`, `preprocess-backfill`) are unchanged.

## Risk notes
- Backward compatible: the new flags both default to `None`, so no existing invocation changes behavior.
- `--env` is intentionally non-clobbering — does not override an already-set `ASTROML_ENV`, matching standard "env wins over flag when set" UX.
- No new runtime dependencies.

---
_Note: this contribution was authored with AI assistance (Claude Code)._