### PR TITLE
feat: add production Docker deployment setup

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+# AstroML Production Deployment Script
+# Usage: ./deploy.sh [start|stop|restart|status|logs]
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Functions
+log() {
+    echo -e "${GREEN}[$(date +'%Y-%m-%d %H:%M:%S')]${NC} $1"
+}
+
+warn() {
+    echo -e "${YELLOW}[$(date +'%Y-%m-%d %H:%M:%S')] WARNING:${NC} $1"
+}
+
+error() {
+    echo -e "${RED}[$(date +'%Y-%m-%d %H:%M:%S')] ERROR:${NC} $1"
+    exit 1
+}
+
+# Check if .env file exists
+check_env() {
+    if [ ! -f .env ]; then
+        if [ -f .env.example ]; then
+            warn ".env file not found. Copying from .env.example"
+            cp .env.example .env
+            warn "Please edit .env and set POSTGRES_PASSWORD before continuing"
+            exit 1
+        else
+            error ".env file not found. Please create one with required variables"
+        fi
+    fi
+    
+    # Source .env
+    source .env
+    
+    # Check required variables
+    if [ -z "$POSTGRES_PASSWORD" ]; then
+        error "POSTGRES_PASSWORD is not set in .env"
+    fi
+}
+
+# Start services
+start() {
+    log "Starting AstroML production services..."
+    check_env
+    
+    docker compose -f docker-compose.prod.yml up -d
+    
+    log "Waiting for services to be healthy..."
+    sleep 10
+    
+    # Check health
+    check_health
+    
+    log "AstroML production services started successfully!"
+    log "Feature Store API: http://localhost:${FEATURE_STORE_PORT:-8000}"
+    log "PostgreSQL: localhost:${POSTGRES_PORT:-5432}"
+    log "Redis: localhost:${REDIS_PORT:-6379}"
+}
+
+# Stop services
+stop() {
+    log "Stopping AstroML production services..."
+    docker compose -f docker-compose.prod.yml down
+    log "Services stopped"
+}
+
+# Restart services
+restart() {
+    stop
+    start
+}
+
+# Check service health
+check_health() {
+    log "Checking service health..."
+    
+    # PostgreSQL
+    if docker compose -f docker-compose.prod.yml exec -T postgres pg_isready -U ${POSTGRES_USER:-astroml} > /dev/null 2>&1; then
+        log "✅ PostgreSQL is healthy"
+    else
+        warn "⚠️  PostgreSQL is not ready"
+    fi
+    
+    # Redis
+    if docker compose -f docker-compose.prod.yml exec -T redis redis-cli ping > /dev/null 2>&1; then
+        log "✅ Redis is healthy"
+    else
+        warn "⚠️  Redis is not ready"
+    fi
+    
+    # Feature Store
+    if curl -s http://localhost:${FEATURE_STORE_PORT:-8000}/health > /dev/null 2>&1; then
+        log "✅ Feature Store is healthy"
+    else
+        warn "⚠️  Feature Store is not ready"
+    fi
+}
+
+# Show status
+status() {
+    log "Service status:"
+    docker compose -f docker-compose.prod.yml ps
+}
+
+# Show logs
+logs() {
+    docker compose -f docker-compose.prod.yml logs -f
+}
+
+# Main
+case "$1" in
+    start)
+        start
+        ;;
+    stop)
+        stop
+        ;;
+    restart)
+        restart
+        ;;
+    status)
+        status
+        ;;
+    logs)
+        logs
+        ;;
+    *)
+        echo "Usage: $0 {start|stop|restart|status|logs}"
+        exit 1
+        ;;
+esac

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,220 @@
+# AstroML Production Docker Compose
+# Optimized for production deployment with health checks, resource limits, and logging
+
+version: '3.8'
+
+services:
+  # PostgreSQL Database - Production
+  postgres:
+    image: postgres:15-alpine
+    container_name: astroml-postgres-prod
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-astroml}
+      POSTGRES_USER: ${POSTGRES_USER:-astroml}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
+      POSTGRES_INITDB_ARGS: "--encoding=UTF-8 --lc-collate=C --lc-ctype=C"
+    ports:
+      - "${POSTGRES_PORT:-5432}:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+      - ./migrations:/docker-entrypoint-initdb.d
+    networks:
+      - astroml-network
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-astroml} -d ${POSTGRES_DB:-astroml}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          cpus: '2.0'
+          memory: 2G
+        reservations:
+          cpus: '0.5'
+          memory: 512M
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+  # Redis - Production
+  redis:
+    image: redis:7-alpine
+    container_name: astroml-redis-prod
+    command: redis-server --appendonly yes --maxmemory 512mb --maxmemory-policy allkeys-lru
+    ports:
+      - "${REDIS_PORT:-6379}:6379"
+    volumes:
+      - redis_data:/data
+    networks:
+      - astroml-network
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          cpus: '1.0'
+          memory: 1G
+        reservations:
+          cpus: '0.25'
+          memory: 256M
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+  # AstroML Ingestion Service
+  ingestion:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: production
+    container_name: astroml-ingestion-prod
+    environment:
+      ASTROML_ENV: production
+      DATABASE_URL: postgresql://${POSTGRES_USER:-astroml}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-astroml}
+      REDIS_URL: redis://redis:6379/0
+      FEATURE_STORE_PATH: /app/feature_store
+    volumes:
+      - feature_store:/app/feature_store
+      - ./config:/app/config:ro
+    networks:
+      - astroml-network
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "python", "-c", "import astroml.ingestion; import astroml.features; print('OK')"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          cpus: '4.0'
+          memory: 8G
+        reservations:
+          cpus: '1.0'
+          memory: 2G
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
+        max-file: "5"
+
+  # AstroML Training Service
+  training:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: training
+    container_name: astroml-training-prod
+    environment:
+      ASTROML_ENV: production
+      DATABASE_URL: postgresql://${POSTGRES_USER:-astroml}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-astroml}
+      REDIS_URL: redis://redis:6379/0
+      FEATURE_STORE_PATH: /app/feature_store
+      CUDA_VISIBLE_DEVICES: ${CUDA_VISIBLE_DEVICES:-0}
+    volumes:
+      - feature_store:/app/feature_store
+      - ./config:/app/config:ro
+      - model_store:/app/models
+    networks:
+      - astroml-network
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "python", "-c", "import torch; import astroml.features; print('OK')"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 120s
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          cpus: '8.0'
+          memory: 32G
+        reservations:
+          cpus: '2.0'
+          memory: 4G
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
+        max-file: "5"
+
+  # Feature Store Service
+  feature-store:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: feature-store
+    container_name: astroml-feature-store-prod
+    environment:
+      ASTROML_ENV: production
+      DATABASE_URL: postgresql://${POSTGRES_USER:-astroml}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-astroml}
+      REDIS_URL: redis://redis:6379/0
+      FEATURE_STORE_PATH: /app/feature_store
+    ports:
+      - "${FEATURE_STORE_PORT:-8000}:8000"
+    volumes:
+      - feature_store:/app/feature_store
+    networks:
+      - astroml-network
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "python", "-c", "from astroml.features import create_feature_store; store = create_feature_store('/app/feature_store'); print('OK')"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          cpus: '2.0'
+          memory: 4G
+        reservations:
+          cpus: '0.5'
+          memory: 1G
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "50m"
+        max-file: "5"
+
+volumes:
+  postgres_data:
+    driver: local
+  redis_data:
+    driver: local
+  feature_store:
+    driver: local
+  model_store:
+    driver: local
+
+networks:
+  astroml-network:
+    driver: bridge


### PR DESCRIPTION
## Description

Add production-ready Docker deployment setup with health checks, resource limits, and deployment automation.

### Changes

**docker-compose.prod.yml:**
- Production-optimized Docker Compose configuration
- Resource limits and reservations for all services (PostgreSQL, Redis, Ingestion, Training, Feature Store)
- Proper health checks with start periods
- JSON logging with rotation (50MB max, 5 files)
- Persistent volumes for data persistence
- Network isolation

**deploy/deploy.sh:**
- Deployment script with start/stop/restart/status/logs commands
- Environment validation (checks .env and required variables)
- Health check verification after startup

### Usage

```bash
# Copy and configure environment
cp .env.example .env
# Edit .env and set POSTGRES_PASSWORD

# Start production services
./deploy/deploy.sh start

# Check status
./deploy/deploy.sh status

# View logs
./deploy/deploy.sh logs
```

Closes #123