### PR TITLE
docs: add reference to REQUIREMENTS.md in setup instructions (#157)

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,8 @@ source venv/bin/activate
 pip install -r requirements.txt
 ```
 
+> **Note:** Three requirements files are available. See [REQUIREMENTS.md](REQUIREMENTS.md) for guidance on which to use based on your environment (GPU training, CPU-only, or minimal config-only).
+
 ### 3. Configure database
 
 A lightweight Docker Compose setup is provided to spin up PostgreSQL and Redis with persistent volumes. Simply run:


### PR DESCRIPTION
- 
  ## Summary
  
  This PR resolves the documentation gap around the three requirements files by improving discoverability and linking users to
  comprehensive guidance.
  
  ## Changes
  
  ### 📝 Documentation Updates
  - **README.md**: Added a note in the setup instructions that directs users to `REQUIREMENTS.md` for guidance on selecting the
  appropriate requirements file based on their environment
  
  ### 🔍 What was verified
  - ✅ All three requirements files (`requirements.txt`, `requirements-cpu.txt`, `requirements-minimal.txt`) maintain consistent
  version pins for shared packages
  - ✅ Existing `REQUIREMENTS.md` documentation is comprehensive and accurate with:
    - Clear decision tree for environment-based selection
    - Detailed purpose and use case for each file
    - Pin policy table ensuring version consistency
    - Guidance on when to use each file
  
  ## Issue Resolution
  
  ### Issue #157: `requirements.txt` and `requirements-cpu.txt` divergence unclear
  
  **Problem**: Differences between the three requirements files were undocumented and unclear to users.
  
  **Solution**: 
  1. Verified that comprehensive documentation already exists in `REQUIREMENTS.md`
  2. Enhanced discoverability by adding a reference in the main `README.md` setup section
  3. Users are now directed to clear guidance on:
     - When to use `requirements.txt` (GPU training stack)
     - When to use `requirements-cpu.txt` (CPU-only training stack)
     - When to use `requirements-minimal.txt` (Hydra + dataframes only)
  
  ## Testing
  
  - Verified all three requirements files have consistent version pins for shared packages
  - Confirmed `REQUIREMENTS.md` accurately documents all differences and use cases
  - README now clearly directs users to the comprehensive requirements documentation
  
  ## Closes
  
  Closes #157
  
  