### PR TITLE
docs: add comprehensive PR checklist to CONTRIBUTING.md (#171)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -333,6 +333,44 @@ Before submitting a PR:
 
 ## PR Process
 
+### PR Checklist
+
+Every pull request **must** pass all of the following before requesting review.
+Copy this checklist into your PR description and tick each item.
+
+#### Tests
+- [ ] `pytest tests/ -v` passes locally with no failures
+- [ ] New functionality has unit tests covering the happy path and edge cases
+- [ ] Any new async functions are tested with `@pytest.mark.asyncio`
+- [ ] Integration tests pass against a real database (not mocked) where applicable
+- [ ] No hardcoded test data paths — fixtures and `test_data/` only
+
+#### Lint & Style
+- [ ] `black --check astroml/ tests/` reports no formatting violations
+- [ ] `flake8 astroml/ tests/` reports no errors (line length ≤ 88)
+- [ ] `mypy astroml/` passes with no new type errors
+- [ ] All public functions/classes have Google-style docstrings
+- [ ] Type hints are present on all new function signatures
+
+#### Changelog & Docs
+- [ ] `CHANGELOG.md` entry added under `## [Unreleased]` describing the change
+- [ ] `README.md` updated if new features, CLI flags, or config keys were added
+- [ ] Any new config fields are documented in the relevant YAML file
+- [ ] Example scripts in `examples/` updated or added where appropriate
+
+#### Security & Safety
+- [ ] No secrets, credentials, or API keys in the diff
+- [ ] No hardcoded file paths pointing to local machine directories
+- [ ] Database migrations include a safe `downgrade` function
+- [ ] Random seeds are fixed for any reproducibility-sensitive tests
+
+#### Reproducibility (pipeline changes only)
+- [ ] Checksums/snapshots updated in `test_snapshots/` if graph output changed
+- [ ] Hyperparameter changes are config-driven (not hardcoded)
+- [ ] `CHANGELOG.md` notes any model output or feature change that breaks reproducibility
+
+---
+
 ### Before Opening a PR
 
 1. **Sync with upstream:**
@@ -343,11 +381,17 @@ Before submitting a PR:
 
 2. **Run linting & tests locally:**
    ```bash
-   # Check for obvious issues
-   python -m py_compile astroml/**/*.py
-   
-   # Run full test suite
-   pytest tests/ -v
+   # Format check
+   black --check astroml/ tests/
+
+   # Lint
+   flake8 astroml/ tests/
+
+   # Type check
+   mypy astroml/
+
+   # Full test suite
+   pytest tests/ -v --cov=astroml
    ```
 
 3. **Ensure commits are clean:**


### PR DESCRIPTION
## Summary

`CONTRIBUTING.md` described the PR workflow in prose but lacked a copyable checklist for tests, lint, and changelog. Contributors had to infer requirements, leading to inconsistent PR quality and review friction.

### Changes

**`CONTRIBUTING.md`** — added a `### PR Checklist` section at the top of the PR Process block with five groups of checkboxes contributors must tick before requesting review:

| Group | Items |
|-------|-------|
| **Tests** | `pytest` passes; new unit/async/integration tests added; no hardcoded paths; fixtures used |
| **Lint & Style** | `black --check`, `flake8`, `mypy` clean; docstrings on all public APIs; type hints present |
| **Changelog & Docs** | `CHANGELOG.md` entry under `[Unreleased]`; README updated; config fields documented; examples added |
| **Security & Safety** | No secrets/credentials; safe migration `downgrade`; fixed seeds for reproducibility |
| **Reproducibility** | Snapshot/checksum files updated; hyperparameters config-driven; breaking model changes noted |

Also expanded the **Before Opening a PR** step 2 to include `black`, `flake8`, and `mypy` commands alongside `pytest`, giving contributors a single copy-paste block for local validation.

### Why this matters

- New contributors now have a clear, scannable checklist to self-review before opening a PR
- Reviewers can reference specific checklist items in feedback instead of re-explaining standards
- Reduces back-and-forth on lint/test/changelog omissions

Closes #171
Closes #164
Closes #161
Closes #153