### PR TITLE
feat(api): ORM-backed integration tests + API CI stage

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -81,3 +81,36 @@ jobs:
         import subprocess
         subprocess.check_call(["pytest", "-v", "-m", "gpu"])
         PY
+
+  # ── Issue #244: API integration tests ────────────────────────────────────────
+  test-api:
+    name: API integration tests (py3.11)
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.11"
+        cache: pip
+        cache-dependency-path: |
+          requirements*.txt
+
+    - name: Install dependencies
+      env:
+        PIP_CACHE_DIR: ~/.cache/pip
+      run: |
+        python -m pip install --upgrade pip
+        pip install pytest pytest-asyncio pytest-xdist httpx fastapi sqlalchemy
+        if [ -f requirements-cpu.txt ]; then
+          pip install -r requirements-cpu.txt
+        elif [ -f requirements.txt ]; then
+          pip install -r requirements.txt
+        fi
+        pip install -e . --no-deps
+
+    - name: Run API integration tests
+      # Uses SQLite in-memory via conftest.py — no Postgres needed in CI.
+      run: pytest api/tests/ -v --tb=short -p no:randomly

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help quickstart test lint format clean install
+.PHONY: help quickstart test test-api lint format clean install
 
 help:
 	@echo "AstroML Development Commands"
@@ -6,7 +6,8 @@ help:
 	@echo ""
 	@echo "make quickstart          Run quick start: ingestion → graph → train pipeline"
 	@echo "make quickstart-verbose  Run quick start with verbose output"
-	@echo "make test                Run test suite"
+	@echo "make test                Run full test suite"
+	@echo "make test-api            Run API integration tests only"
 	@echo "make lint                Run linters (flake8, mypy)"
 	@echo "make format              Format code (black, isort)"
 	@echo "make install             Install development dependencies"
@@ -21,6 +22,9 @@ quickstart-verbose:
 
 test:
 	pytest tests/ -v
+
+test-api:
+	pytest api/tests/ -v --tb=short
 
 lint:
 	flake8 astroml/ tests/

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -1,31 +1,45 @@
 """
 Shared pytest fixtures for API integration tests.
 
-Issue #264 — Integration tests for API endpoints and CI pipeline.
+Issue #244 — Integration tests for API endpoints and CI pipeline.
+Issue #246 — Database Session & Models.
 
 Provides:
-  - `db_session`  : in-memory SQLite session (no Postgres needed in CI)
-  - `sample_accounts`, `sample_transactions`, `sample_alerts`: seed data
+  - `db_engine`             : ephemeral SQLite engine per test function
+  - `db_session`            : isolated session (rolled back on teardown)
+  - `client`                : FastAPI TestClient with DB override
+  - `seeded_account`        : one Account row in the test DB
+  - `seeded_transaction`    : one Transaction row in the test DB
+  - `seeded_alert`          : one FraudAlert row in the test DB
+  - `seeded_loyalty`        : one LoyaltyPoints row in the test DB
+  - `sample_accounts`       : raw list-of-dicts (no DB) for unit-level tests
+  - `sample_transactions`   : raw list-of-dicts
+  - `sample_alerts`         : raw list-of-dicts
 """
 from __future__ import annotations
 
+from datetime import datetime, timezone
+
 import pytest
+from fastapi.testclient import TestClient
 from sqlalchemy import create_engine, event
-from sqlalchemy.orm import sessionmaker, Session
+from sqlalchemy.orm import Session, sessionmaker
 
-# Import the ORM base so all models are registered
 from astroml.db.schema import Base
-
+import api.models.orm  # noqa: F401 — registers ORM models on Base.metadata
+from api.models.orm import Account, FraudAlert, LoyaltyPoints, PointsTransaction, Transaction
 
 # ─── Engine / session ─────────────────────────────────────────────────────────
 
 @pytest.fixture(scope="function")
 def db_engine(tmp_path):
-    """Ephemeral SQLite engine scoped to this test function (issue #204 pattern)."""
+    """Ephemeral SQLite engine scoped to this test function."""
     db_file = tmp_path / "test_astroml.db"
-    engine = create_engine(f"sqlite:///{db_file}", connect_args={"check_same_thread": False})
+    engine = create_engine(
+        f"sqlite:///{db_file}",
+        connect_args={"check_same_thread": False},
+    )
 
-    # Enable WAL mode for better concurrent-read performance in tests
     @event.listens_for(engine, "connect")
     def set_wal(dbapi_conn, _):
         dbapi_conn.execute("PRAGMA journal_mode=WAL")
@@ -37,7 +51,7 @@ def db_engine(tmp_path):
 
 @pytest.fixture(scope="function")
 def db_session(db_engine) -> Session:
-    """Clean session for each test — all writes are rolled back on teardown."""
+    """Clean session per test — all writes are rolled back on teardown."""
     SessionLocal = sessionmaker(bind=db_engine, autocommit=False, autoflush=False)
     session = SessionLocal()
     yield session
@@ -45,11 +59,88 @@ def db_session(db_engine) -> Session:
     session.close()
 
 
-# ─── Seed data fixtures ───────────────────────────────────────────────────────
+# ─── FastAPI TestClient with DB override ──────────────────────────────────────
+
+@pytest.fixture(scope="function")
+def client(db_session):
+    """FastAPI TestClient with the real DB dependency replaced by the test session."""
+    from api.app import app
+    from api.database import get_sync_db
+
+    def _override_db():
+        yield db_session
+
+    app.dependency_overrides[get_sync_db] = _override_db
+    with TestClient(app, raise_server_exceptions=False) as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+# ─── ORM seed fixtures ────────────────────────────────────────────────────────
+
+@pytest.fixture()
+def seeded_account(db_session) -> Account:
+    acc = Account(
+        public_key="GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN",
+        first_seen=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        last_active=datetime(2024, 6, 1, tzinfo=timezone.utc),
+        balance=1000.0,
+    )
+    db_session.add(acc)
+    db_session.flush()
+    return acc
+
+
+@pytest.fixture()
+def seeded_transaction(db_session) -> Transaction:
+    tx = Transaction(
+        hash="abc123def456abc123def456abc123def456abc123def456abc123def456ab12",
+        ledger_sequence=100,
+        source_account="GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN",
+        destination_account="GBZXN7PIRZGNMHGA7MUUUF4GWPY5AYPGZWXNBFNKKZ4YH67FQJG2FZT",
+        amount=500.0,
+        asset_code="XLM",
+        fee=100,
+        successful=True,
+        created_at=datetime(2024, 6, 1, tzinfo=timezone.utc),
+    )
+    db_session.add(tx)
+    db_session.flush()
+    return tx
+
+
+@pytest.fixture()
+def seeded_alert(db_session) -> FraudAlert:
+    alert = FraudAlert(
+        account_id="GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN",
+        pattern="sybil_cluster",
+        risk_score=0.92,
+        risk_level="high",
+        description="Suspicious transaction velocity detected.",
+        detected_at=datetime(2024, 6, 1, tzinfo=timezone.utc),
+    )
+    db_session.add(alert)
+    db_session.flush()
+    return alert
+
+
+@pytest.fixture()
+def seeded_loyalty(db_session) -> LoyaltyPoints:
+    lp = LoyaltyPoints(
+        account_id="GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN",
+        balance=2500,
+        tier="silver",
+        multiplier=1.1,
+    )
+    db_session.add(lp)
+    db_session.flush()
+    return lp
+
+
+# ─── Raw dict fixtures (no DB, unit-level) ────────────────────────────────────
 
 @pytest.fixture()
 def sample_accounts():
-    """Minimal account dicts for use as test data."""
     return [
         {"account_id": "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN", "sequence": 1},
         {"account_id": "GBZXN7PIRZGNMHGA7MUUUF4GWPY5AYPGZWXNBFNKKZ4YH67FQJG2FZT", "sequence": 2},
@@ -59,7 +150,6 @@ def sample_accounts():
 
 @pytest.fixture()
 def sample_transactions():
-    """Minimal transaction dicts for use as test data."""
     return [
         {
             "transaction_hash": "abc123",
@@ -90,8 +180,17 @@ def sample_transactions():
 
 @pytest.fixture()
 def sample_alerts():
-    """Minimal alert dicts for fraud/anomaly detection tests."""
     return [
-        {"alert_id": "a1", "account_id": "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN", "severity": "high", "resolved": False},
-        {"alert_id": "a2", "account_id": "GBZXN7PIRZGNMHGA7MUUUF4GWPY5AYPGZWXNBFNKKZ4YH67FQJG2FZT", "severity": "low",  "resolved": True},
+        {
+            "alert_id": "a1",
+            "account_id": "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN",
+            "severity": "high",
+            "resolved": False,
+        },
+        {
+            "alert_id": "a2",
+            "account_id": "GBZXN7PIRZGNMHGA7MUUUF4GWPY5AYPGZWXNBFNKKZ4YH67FQJG2FZT",
+            "severity": "low",
+            "resolved": True,
+        },
     ]

--- a/api/tests/test_fraud.py
+++ b/api/tests/test_fraud.py
@@ -1,0 +1,100 @@
+"""
+Integration tests — fraud detection (issue #244).
+
+Covers: ORM model creation, risk-level classification, alert filtering,
+stats aggregation, and score/alert endpoint shapes.
+"""
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import select
+
+from api.models.orm import FraudAlert
+
+
+@pytest.mark.xdist_group("api_fraud")
+class TestFraudAlertModel:
+    """ORM-level tests for FraudAlert (issue #246)."""
+
+    def test_create_alert_persists(self, db_session):
+        alert = FraudAlert(
+            account_id="GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN",
+            pattern="velocity",
+            risk_score=0.75,
+            risk_level="medium",
+            description="Burst of micro-transactions.",
+        )
+        db_session.add(alert)
+        db_session.flush()
+        assert alert.id is not None
+
+    def test_risk_level_high(self):
+        assert FraudAlert.risk_level_for_score(0.85) == "high"
+        assert FraudAlert.risk_level_for_score(0.8) == "high"
+
+    def test_risk_level_medium(self):
+        assert FraudAlert.risk_level_for_score(0.79) == "medium"
+        assert FraudAlert.risk_level_for_score(0.5) == "medium"
+
+    def test_risk_level_low(self):
+        assert FraudAlert.risk_level_for_score(0.49) == "low"
+        assert FraudAlert.risk_level_for_score(0.0) == "low"
+
+    def test_seeded_alert_fields(self, seeded_alert):
+        assert seeded_alert.account_id == "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN"
+        assert seeded_alert.risk_score == pytest.approx(0.92)
+        assert seeded_alert.risk_level == "high"
+        assert seeded_alert.pattern == "sybil_cluster"
+
+    def test_multiple_alerts_query(self, db_session):
+        for score in [0.9, 0.6, 0.3]:
+            db_session.add(FraudAlert(
+                account_id="GBZXN7PIRZGNMHGA7MUUUF4GWPY5AYPGZWXNBFNKKZ4YH67FQJG2FZT",
+                risk_score=score,
+                risk_level=FraudAlert.risk_level_for_score(score),
+            ))
+        db_session.flush()
+
+        results = db_session.execute(select(FraudAlert)).scalars().all()
+        assert len(results) == 3
+
+    def test_filter_by_risk_level(self, db_session):
+        for score, level in [(0.9, "high"), (0.6, "medium"), (0.2, "low")]:
+            db_session.add(FraudAlert(
+                account_id="GCKFBEIYV2U22IO2BJ4KVJOIP7XPWQGQFKKWXR6DOSJBV5SG3B3ORJF",
+                risk_score=score,
+                risk_level=level,
+            ))
+        db_session.flush()
+
+        high = db_session.execute(
+            select(FraudAlert).where(FraudAlert.risk_level == "high")
+        ).scalars().all()
+        assert len(high) == 1
+        assert high[0].risk_score == pytest.approx(0.9)
+
+
+@pytest.mark.xdist_group("api_fraud")
+class TestFraudFixtures:
+    """Verify raw dict fixtures remain intact for backward-compat tests."""
+
+    def test_sample_alerts_count(self, sample_alerts):
+        assert len(sample_alerts) == 2
+
+    def test_sample_alerts_have_required_fields(self, sample_alerts):
+        for alert in sample_alerts:
+            assert "alert_id" in alert
+            assert "account_id" in alert
+            assert "severity" in alert
+            assert "resolved" in alert
+
+    def test_filter_unresolved_alerts(self, sample_alerts):
+        unresolved = [a for a in sample_alerts if not a["resolved"]]
+        assert len(unresolved) == 1
+        assert unresolved[0]["severity"] == "high"
+
+    def test_filter_by_severity(self, sample_alerts):
+        high = [a for a in sample_alerts if a["severity"] == "high"]
+        low = [a for a in sample_alerts if a["severity"] == "low"]
+        assert len(high) == 1
+        assert len(low) == 1

--- a/api/tests/test_health.py
+++ b/api/tests/test_health.py
@@ -1,0 +1,28 @@
+"""
+Integration tests — health check endpoint (issue #244).
+
+Covers: /health returns 200 with expected payload.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.xdist_group("api_health")
+class TestHealthEndpoint:
+
+    def test_health_returns_200(self, client):
+        resp = client.get("/health")
+        assert resp.status_code == 200
+
+    def test_health_response_is_json(self, client):
+        resp = client.get("/health")
+        assert resp.headers["content-type"].startswith("application/json")
+
+    def test_health_has_status_field(self, client):
+        data = client.get("/health").json()
+        assert "status" in data
+
+    def test_health_status_ok(self, client):
+        data = client.get("/health").json()
+        assert data["status"] in {"ok", "healthy", "up"}

--- a/api/tests/test_loyalty.py
+++ b/api/tests/test_loyalty.py
@@ -1,0 +1,132 @@
+"""
+Integration tests — loyalty points (issue #244).
+
+Covers: ORM model creation, tier logic, points transactions,
+balance queries, and history pagination.
+"""
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import select
+
+from api.models.orm import LoyaltyPoints, PointsTransaction
+
+
+@pytest.mark.xdist_group("api_loyalty")
+class TestLoyaltyPointsModel:
+    """ORM-level tests for LoyaltyPoints (issue #246)."""
+
+    def test_create_loyalty_row(self, db_session):
+        lp = LoyaltyPoints(
+            account_id="GBZXN7PIRZGNMHGA7MUUUF4GWPY5AYPGZWXNBFNKKZ4YH67FQJG2FZT",
+            balance=500,
+            tier="bronze",
+            multiplier=1.0,
+        )
+        db_session.add(lp)
+        db_session.flush()
+        assert lp.id is not None
+
+    def test_seeded_loyalty_fields(self, seeded_loyalty):
+        assert seeded_loyalty.balance == 2500
+        assert seeded_loyalty.tier == "silver"
+        assert seeded_loyalty.multiplier == pytest.approx(1.1)
+
+    def test_unique_account_constraint(self, db_session, seeded_loyalty):
+        duplicate = LoyaltyPoints(
+            account_id=seeded_loyalty.account_id,
+            balance=0,
+            tier="bronze",
+            multiplier=1.0,
+        )
+        db_session.add(duplicate)
+        with pytest.raises(Exception):
+            db_session.flush()
+
+    def test_query_by_account(self, db_session, seeded_loyalty):
+        result = db_session.execute(
+            select(LoyaltyPoints).where(
+                LoyaltyPoints.account_id == seeded_loyalty.account_id
+            )
+        ).scalar_one()
+        assert result.balance == 2500
+
+
+@pytest.mark.xdist_group("api_loyalty")
+class TestPointsTransactionModel:
+    """ORM-level tests for PointsTransaction (issue #246)."""
+
+    def test_create_earn_transaction(self, db_session):
+        pt = PointsTransaction(
+            account_id="GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN",
+            type="earn",
+            points=100,
+            source="trade_completion",
+        )
+        db_session.add(pt)
+        db_session.flush()
+        assert pt.id is not None
+
+    def test_create_redeem_transaction(self, db_session):
+        pt = PointsTransaction(
+            account_id="GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN",
+            type="redeem",
+            points=-200,
+            source="reward_redemption",
+        )
+        db_session.add(pt)
+        db_session.flush()
+        assert pt.points == -200
+
+    def test_history_ordering(self, db_session):
+        account = "GCKFBEIYV2U22IO2BJ4KVJOIP7XPWQGQFKKWXR6DOSJBV5SG3B3ORJF"
+        from datetime import datetime, timezone, timedelta
+        base = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        for i, pts in enumerate([50, 100, -30]):
+            pt = PointsTransaction(
+                account_id=account,
+                type="earn" if pts > 0 else "redeem",
+                points=pts,
+                source=f"event_{i}",
+            )
+            db_session.add(pt)
+        db_session.flush()
+
+        rows = db_session.execute(
+            select(PointsTransaction)
+            .where(PointsTransaction.account_id == account)
+            .order_by(PointsTransaction.id)
+        ).scalars().all()
+        assert len(rows) == 3
+        assert rows[0].points == 50
+        assert rows[2].points == -30
+
+    def test_net_balance_calculation(self, db_session):
+        account = "GBZXN7PIRZGNMHGA7MUUUF4GWPY5AYPGZWXNBFNKKZ4YH67FQJG2FZT"
+        for pts in [200, 50, -75]:
+            db_session.add(PointsTransaction(
+                account_id=account,
+                type="earn" if pts > 0 else "redeem",
+                points=pts,
+            ))
+        db_session.flush()
+
+        rows = db_session.execute(
+            select(PointsTransaction).where(PointsTransaction.account_id == account)
+        ).scalars().all()
+        net = sum(r.points for r in rows)
+        assert net == 175
+
+    def test_filter_by_type(self, db_session):
+        account = "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN"
+        for t, pts in [("earn", 100), ("redeem", -50), ("adjust", 10)]:
+            db_session.add(PointsTransaction(account_id=account, type=t, points=pts))
+        db_session.flush()
+
+        earns = db_session.execute(
+            select(PointsTransaction).where(
+                PointsTransaction.account_id == account,
+                PointsTransaction.type == "earn",
+            )
+        ).scalars().all()
+        assert len(earns) == 1

--- a/api/tests/test_monitoring.py
+++ b/api/tests/test_monitoring.py
@@ -1,0 +1,88 @@
+"""
+Integration tests — model monitoring (issue #244).
+
+Covers: metrics endpoint shape, history endpoint, latency recording,
+drift report structure, and prediction stats.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.xdist_group("api_monitoring")
+class TestMonitoringMetrics:
+    """Verify /api/v1/monitoring/metrics returns required fields."""
+
+    def test_metrics_endpoint_returns_200(self, client):
+        resp = client.get("/api/v1/monitoring/metrics")
+        assert resp.status_code == 200
+
+    def test_metrics_response_has_required_fields(self, client):
+        data = client.get("/api/v1/monitoring/metrics").json()
+        required = {"accuracy", "precision", "recall", "f1_score", "auc_roc"}
+        assert required.issubset(data.keys()), f"missing keys: {required - data.keys()}"
+
+    def test_metrics_values_are_numeric(self, client):
+        data = client.get("/api/v1/monitoring/metrics").json()
+        for key in ("accuracy", "precision", "recall", "f1_score", "auc_roc"):
+            assert isinstance(data[key], (int, float))
+
+
+@pytest.mark.xdist_group("api_monitoring")
+class TestMonitoringHistory:
+    """Verify /api/v1/monitoring/performance-history returns a list."""
+
+    def test_history_endpoint_returns_200(self, client):
+        resp = client.get("/api/v1/monitoring/performance-history")
+        assert resp.status_code == 200
+
+    def test_history_is_list(self, client):
+        data = client.get("/api/v1/monitoring/performance-history").json()
+        assert isinstance(data, list)
+
+
+@pytest.mark.xdist_group("api_monitoring")
+class TestMonitoringDriftReport:
+    """Verify /api/v1/monitoring/drift-report returns expected structure."""
+
+    def test_drift_report_returns_200(self, client):
+        resp = client.get("/api/v1/monitoring/drift-report")
+        assert resp.status_code == 200
+
+    def test_drift_report_has_features(self, client):
+        data = client.get("/api/v1/monitoring/drift-report").json()
+        assert "features" in data
+
+
+@pytest.mark.xdist_group("api_monitoring")
+class TestMonitoringLatency:
+    """Verify /api/v1/monitoring/latency returns expected structure."""
+
+    def test_latency_endpoint_returns_200(self, client):
+        resp = client.get("/api/v1/monitoring/latency")
+        assert resp.status_code == 200
+
+    def test_latency_has_percentile_fields(self, client):
+        data = client.get("/api/v1/monitoring/latency").json()
+        assert "p50_ms" in data
+        assert "p95_ms" in data
+        assert "p99_ms" in data
+
+    def test_latency_values_non_negative(self, client):
+        data = client.get("/api/v1/monitoring/latency").json()
+        for key in ("p50_ms", "p95_ms", "p99_ms"):
+            assert data[key] >= 0
+
+
+@pytest.mark.xdist_group("api_monitoring")
+class TestMonitoringPredictionStats:
+    """Verify /api/v1/monitoring/prediction-stats structure."""
+
+    def test_prediction_stats_returns_200(self, client):
+        resp = client.get("/api/v1/monitoring/prediction-stats")
+        assert resp.status_code == 200
+
+    def test_prediction_stats_has_total(self, client):
+        data = client.get("/api/v1/monitoring/prediction-stats").json()
+        assert "total_predictions" in data
+        assert isinstance(data["total_predictions"], int)


### PR DESCRIPTION
## Summary

- Adds comprehensive ORM-backed integration tests for the API layer using SQLite in-memory (no Postgres needed in CI)
- Wires a dedicated `test-api` job into `.github/workflows/pytest.yml` and adds `make test-api` to the Makefile

## Issue #246 — Database Session & Models

The ORM models (`Account`, `Transaction`, `FraudAlert`, `LoyaltyPoints`, `PointsTransaction`, `ModelRegistry`) and async/sync session management (`api/database.py`) are already implemented. This PR adds tests that exercise them against a real (SQLite) database.

## Issue #244 — Integration Tests & CI

### New files

| File | What it tests |
|------|--------------|
| `api/tests/conftest.py` | Enhanced: ORM seed fixtures (`seeded_account`, `seeded_transaction`, `seeded_alert`, `seeded_loyalty`) + FastAPI `TestClient` with DB dependency override |
| `api/tests/test_fraud.py` | `FraudAlert` ORM CRUD, `risk_level_for_score()`, multi-alert queries, filter by risk level, raw dict fixtures |
| `api/tests/test_loyalty.py` | `LoyaltyPoints` + `PointsTransaction` create/read, unique constraint, history ordering, net balance, filter by type |
| `api/tests/test_monitoring.py` | `/api/v1/monitoring/metrics`, `/performance-history`, `/drift-report`, `/latency`, `/prediction-stats` shape and field tests |
| `api/tests/test_health.py` | `/health` → 200, JSON content-type, `status` field present |

### CI changes

- `.github/workflows/pytest.yml`: new `test-api` job (Python 3.11, SQLite, `pytest api/tests/`)
- `Makefile`: `make test-api` target

closes #244
closes #246