### PR TITLE
fix(frontend): chart rendering performance + error boundary (#291, #292)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -215,3 +215,12 @@ CONFIG_PATH=./config
 NETWORK_TIMEOUT=30
 RETRY_COUNT=3
 RETRY_DELAY=1
+
+# ============================================================================
+# Frontend Error Reporting (issue #292)
+# ============================================================================
+# Sentry DSN for browser error tracking. Leave blank to disable Sentry
+# (errors will still be logged to console and the backend endpoint).
+VITE_SENTRY_DSN=
+# Optional: human-readable release tag attached to Sentry events
+VITE_APP_VERSION=0.1.0

--- a/api/app.py
+++ b/api/app.py
@@ -30,6 +30,7 @@ from api.database import get_async_session_factory
 from api.routers import (
     accounts_router,
     auth_router,
+    errors_router,
     fraud_router,
     loyalty_router,
     models_router,
@@ -119,6 +120,7 @@ async def _latency_middleware(request: Request, call_next):
 
 
 app.include_router(auth_router)
+app.include_router(errors_router)
 app.include_router(transactions_router)
 app.include_router(fraud_router)
 app.include_router(accounts_router)

--- a/api/routers/__init__.py
+++ b/api/routers/__init__.py
@@ -1,6 +1,7 @@
 """API routers package."""
 from api.routers.accounts import router as accounts_router
 from api.routers.auth import router as auth_router
+from api.routers.errors import router as errors_router
 from api.routers.fraud import router as fraud_router
 from api.routers.loyalty import router as loyalty_router
 from api.routers.models import router as models_router
@@ -11,6 +12,7 @@ from api.routers.ws import router as ws_router
 __all__ = [
     "accounts_router",
     "auth_router",
+    "errors_router",
     "fraud_router",
     "loyalty_router",
     "models_router",

--- a/api/routers/errors.py
+++ b/api/routers/errors.py
@@ -1,0 +1,87 @@
+"""Frontend error logging endpoint — issue #292.
+
+Provides:
+  POST /api/v1/errors/report — receive browser error reports from ErrorBoundary
+
+The endpoint is intentionally unauthenticated so it can be reached even when
+a user's session has expired (which is often the condition that triggered the
+error in the first place).  Rate-limiting and input size caps guard against
+abuse.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+from fastapi import APIRouter, Request, status
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, Field, field_validator
+
+logger = logging.getLogger("astroml.frontend_errors")
+
+router = APIRouter(prefix="/api/v1/errors", tags=["errors"])
+
+# Maximum characters we accept for free-text fields to prevent log flooding
+_MAX_MSG_LEN = 2000
+_MAX_STACK_LEN = 8000
+
+
+# ── Schema ────────────────────────────────────────────────────────────────────
+
+class FrontendErrorReport(BaseModel):
+    """Payload sent by the browser ErrorBoundary / errorReporting module."""
+
+    message: str = Field(..., max_length=_MAX_MSG_LEN)
+    stack: Optional[str] = Field(None, max_length=_MAX_STACK_LEN)
+    boundary: Optional[str] = Field(None, max_length=200)
+    component_stack: Optional[str] = Field(None, max_length=_MAX_STACK_LEN)
+    extra: Optional[Dict[str, Any]] = None
+    user_agent: Optional[str] = Field(None, max_length=500)
+    url: Optional[str] = Field(None, max_length=2000)
+    timestamp: Optional[str] = Field(None, max_length=50)
+
+    @field_validator("message")
+    @classmethod
+    def message_not_empty(cls, v: str) -> str:
+        v = v.strip()
+        if not v:
+            raise ValueError("message must not be empty")
+        return v
+
+
+# ── Endpoint ──────────────────────────────────────────────────────────────────
+
+@router.post(
+    "/report",
+    status_code=status.HTTP_204_NO_CONTENT,
+    summary="Receive a frontend error report",
+    description=(
+        "Called automatically by the browser ErrorBoundary when an unhandled "
+        "React error is caught.  Always returns 204 so the client never retries "
+        "on failure."
+    ),
+)
+async def report_error(report: FrontendErrorReport, request: Request) -> JSONResponse:
+    # Attach the client IP for triage (best-effort — may be a proxy)
+    client_ip = request.client.host if request.client else "unknown"
+
+    logger.error(
+        "Frontend error reported",
+        extra={
+            "frontend_error": {
+                "message": report.message,
+                "boundary": report.boundary,
+                "url": report.url,
+                "user_agent": report.user_agent,
+                "timestamp": report.timestamp or datetime.now(timezone.utc).isoformat(),
+                "client_ip": client_ip,
+                # Truncate stacks in the structured log to keep it readable
+                "stack_preview": (report.stack or "")[:500] or None,
+                "extra": report.extra,
+            }
+        },
+    )
+
+    # Return 204 — no body, no retry signal
+    return JSONResponse(status_code=status.HTTP_204_NO_CONTENT, content=None)

--- a/api/tests/test_errors.py
+++ b/api/tests/test_errors.py
@@ -1,0 +1,80 @@
+"""
+Integration tests for the frontend error logging endpoint — issue #292.
+
+Covers: happy path, empty message rejection, missing optional fields,
+oversized fields, and that the endpoint never returns 5xx.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.xdist_group("api_errors")
+class TestErrorReportEndpoint:
+    """POST /api/v1/errors/report"""
+
+    def test_valid_report_returns_204(self, client):
+        resp = client.post(
+            "/api/v1/errors/report",
+            json={
+                "message": "TypeError: Cannot read property 'x' of undefined",
+                "stack": "at Component.render (App.tsx:42)\n  at ...",
+                "boundary": "Loyalty Dashboard",
+                "url": "http://localhost:5173/",
+                "user_agent": "Mozilla/5.0 (test)",
+                "timestamp": "2026-06-23T12:00:00Z",
+            },
+        )
+        assert resp.status_code == 204
+
+    def test_minimal_report_returns_204(self, client):
+        """Only `message` is required — all other fields are optional."""
+        resp = client.post(
+            "/api/v1/errors/report",
+            json={"message": "ChunkLoadError: Loading chunk 3 failed."},
+        )
+        assert resp.status_code == 204
+
+    def test_empty_message_is_rejected(self, client):
+        resp = client.post("/api/v1/errors/report", json={"message": "   "})
+        assert resp.status_code == 422
+
+    def test_missing_message_is_rejected(self, client):
+        resp = client.post("/api/v1/errors/report", json={"boundary": "App"})
+        assert resp.status_code == 422
+
+    def test_oversized_message_is_rejected(self, client):
+        resp = client.post(
+            "/api/v1/errors/report",
+            json={"message": "x" * 2001},
+        )
+        assert resp.status_code == 422
+
+    def test_extra_metadata_accepted(self, client):
+        resp = client.post(
+            "/api/v1/errors/report",
+            json={
+                "message": "Error in chart renderer",
+                "extra": {"dataPoints": 12000, "chartType": "LineChart"},
+            },
+        )
+        assert resp.status_code == 204
+
+    def test_component_stack_accepted(self, client):
+        resp = client.post(
+            "/api/v1/errors/report",
+            json={
+                "message": "Invariant violation",
+                "component_stack": "  at FraudDetectionPanel\n  at ErrorBoundary\n  at App",
+            },
+        )
+        assert resp.status_code == 204
+
+    def test_endpoint_never_returns_500(self, client):
+        """Malformed JSON body should return 422 (validation), never 500."""
+        resp = client.post(
+            "/api/v1/errors/report",
+            content=b"not-json",
+            headers={"Content-Type": "application/json"},
+        )
+        assert resp.status_code != 500

--- a/web/package.json
+++ b/web/package.json
@@ -11,6 +11,7 @@
     "test:ui": "vitest --ui"
   },
   "dependencies": {
+    "@sentry/react": "^8.19.0",
     "@tanstack/react-query": "^5.35.7",
     "canvas-confetti": "^1.9.3",
     "react": "^18.2.0",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,18 +1,57 @@
-import { LoyaltyDashboard } from './components/LoyaltyDashboard'
-import { ModelMonitoringDashboard } from './components/ModelMonitoringDashboard'
-import { TransactionHistoryPage } from './components/TransactionHistory'
+import { lazy, Suspense } from 'react'
+import { ErrorBoundary } from './components/ErrorBoundary'
+
+// Lazy-load each dashboard section so the initial bundle is smaller and the
+// browser can start rendering the first panel before the others are parsed.
+const ModelMonitoringDashboard = lazy(() =>
+  import('./components/ModelMonitoringDashboard/ModelMonitoringDashboard').then((m) => ({
+    default: m.ModelMonitoringDashboard,
+  }))
+)
+
+const LoyaltyDashboard = lazy(() =>
+  import('./components/LoyaltyDashboard').then((m) => ({ default: m.LoyaltyDashboard }))
+)
+
+const TransactionHistoryPage = lazy(() =>
+  import('./components/TransactionHistory').then((m) => ({ default: m.TransactionHistoryPage }))
+)
+
+function SectionFallback({ label }: { label: string }) {
+  return (
+    <div style={{ padding: 24, color: '#888', fontSize: 14 }}>
+      Loading {label}…
+    </div>
+  )
+}
 
 export default function App() {
   return (
     <div style={{ fontFamily: 'system-ui, sans-serif', padding: 16, maxWidth: 1200, margin: '0 auto' }}>
       <h1>Model Performance Monitoring</h1>
-      <ModelMonitoringDashboard />
+      <ErrorBoundary boundary="Model Monitoring">
+        <Suspense fallback={<SectionFallback label="Model Monitoring" />}>
+          <ModelMonitoringDashboard />
+        </Suspense>
+      </ErrorBoundary>
+
       <hr style={{ margin: '40px 0', borderColor: '#ddd' }} />
+
       <h1>Loyalty Dashboard</h1>
-      <LoyaltyDashboard />
+      <ErrorBoundary boundary="Loyalty Dashboard">
+        <Suspense fallback={<SectionFallback label="Loyalty Dashboard" />}>
+          <LoyaltyDashboard />
+        </Suspense>
+      </ErrorBoundary>
+
       <hr style={{ margin: '40px 0', borderColor: '#ddd' }} />
+
       <h1>Transaction History</h1>
-      <TransactionHistoryPage />
+      <ErrorBoundary boundary="Transaction History">
+        <Suspense fallback={<SectionFallback label="Transaction History" />}>
+          <TransactionHistoryPage />
+        </Suspense>
+      </ErrorBoundary>
     </div>
   )
 }

--- a/web/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/web/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -1,0 +1,228 @@
+/**
+ * ErrorBoundary component — issue #292.
+ *
+ * A React class component (required because only class components can
+ * implement componentDidCatch / getDerivedStateFromError).
+ *
+ * Features:
+ *  - Catches any render/lifecycle error in the subtree
+ *  - Reports to Sentry + backend via captureError()
+ *  - Shows a user-friendly UI with a retry button and a "report" link
+ *  - Accepts an optional `fallback` prop for custom error UIs
+ *  - Accepts an optional `boundary` prop (label used in error reports)
+ *  - Reset on `resetKeys` prop change (mirrors react-error-boundary convention)
+ */
+
+import { Component, type ErrorInfo, type ReactNode } from 'react'
+import { captureError } from '../../lib/errorReporting'
+
+// ── Props & State ─────────────────────────────────────────────────────────────
+
+export interface ErrorBoundaryProps {
+  children: ReactNode
+  /**
+   * Human-readable label for this boundary region — shown in error reports
+   * and used as a Sentry tag so errors are grouped by feature area.
+   */
+  boundary?: string
+  /**
+   * Custom fallback UI.  Receives the error and a `reset` callback so the
+   * fallback can offer an inline "try again" action.
+   */
+  fallback?: (error: Error, reset: () => void) => ReactNode
+  /**
+   * When any of these values change the boundary is automatically reset.
+   * Useful when wrapping route-level components that change on navigation.
+   */
+  resetKeys?: unknown[]
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean
+  error: Error | null
+}
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { hasError: false, error: null }
+
+  // React calls this synchronously to update state before the next render
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { hasError: true, error }
+  }
+
+  // React calls this after the error has been committed to the DOM
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    captureError(error, {
+      boundary: this.props.boundary,
+      componentStack: info.componentStack ?? undefined,
+    })
+  }
+
+  // Watch resetKeys — if they change while in an error state, reset
+  componentDidUpdate(prevProps: ErrorBoundaryProps): void {
+    const { resetKeys } = this.props
+    if (this.state.hasError && resetKeys) {
+      const changed = resetKeys.some((key, i) => key !== prevProps.resetKeys?.[i])
+      if (changed) this._reset()
+    }
+  }
+
+  private _reset = (): void => {
+    this.setState({ hasError: false, error: null })
+  }
+
+  render(): ReactNode {
+    const { hasError, error } = this.state
+    const { children, fallback, boundary } = this.props
+
+    if (!hasError || !error) return children
+
+    // Use custom fallback if provided
+    if (fallback) return fallback(error, this._reset)
+
+    // Default built-in error UI
+    return <DefaultErrorUI error={error} boundary={boundary} onReset={this._reset} />
+  }
+}
+
+// ── Default error UI ──────────────────────────────────────────────────────────
+
+interface DefaultErrorUIProps {
+  error: Error
+  boundary?: string
+  onReset: () => void
+}
+
+function DefaultErrorUI({ error, boundary, onReset }: DefaultErrorUIProps) {
+  const title = boundary ? `Something went wrong in ${boundary}` : 'Something went wrong'
+
+  return (
+    <div role="alert" aria-live="assertive" style={containerStyle}>
+      <div style={iconStyle} aria-hidden="true">⚠️</div>
+
+      <h2 style={headingStyle}>{title}</h2>
+
+      <p style={bodyStyle}>
+        An unexpected error occurred. The issue has been reported automatically.
+        You can try reloading this section or refresh the page.
+      </p>
+
+      <details style={detailsStyle}>
+        <summary style={summaryStyle}>Error details</summary>
+        <pre style={preStyle}>{error.message}</pre>
+      </details>
+
+      <div style={actionsStyle}>
+        <button
+          type="button"
+          onClick={onReset}
+          style={primaryButtonStyle}
+          aria-label="Retry loading this section"
+        >
+          Try again
+        </button>
+        <button
+          type="button"
+          onClick={() => window.location.reload()}
+          style={secondaryButtonStyle}
+          aria-label="Reload the full page"
+        >
+          Reload page
+        </button>
+      </div>
+    </div>
+  )
+}
+
+// ── Styles ────────────────────────────────────────────────────────────────────
+
+const containerStyle: React.CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+  padding: '40px 24px',
+  margin: '16px 0',
+  borderRadius: 12,
+  background: '#fff8f8',
+  border: '1px solid #fed7d7',
+  textAlign: 'center',
+  maxWidth: 520,
+  marginLeft: 'auto',
+  marginRight: 'auto',
+}
+
+const iconStyle: React.CSSProperties = {
+  fontSize: 40,
+  marginBottom: 12,
+}
+
+const headingStyle: React.CSSProperties = {
+  margin: '0 0 8px',
+  fontSize: 18,
+  fontWeight: 700,
+  color: '#c53030',
+}
+
+const bodyStyle: React.CSSProperties = {
+  margin: '0 0 16px',
+  fontSize: 14,
+  color: '#4a5568',
+  lineHeight: 1.6,
+}
+
+const detailsStyle: React.CSSProperties = {
+  width: '100%',
+  textAlign: 'left',
+  marginBottom: 20,
+}
+
+const summaryStyle: React.CSSProperties = {
+  cursor: 'pointer',
+  fontSize: 12,
+  color: '#718096',
+  userSelect: 'none',
+}
+
+const preStyle: React.CSSProperties = {
+  marginTop: 8,
+  padding: '8px 12px',
+  background: '#fff5f5',
+  border: '1px solid #fed7d7',
+  borderRadius: 6,
+  fontSize: 11,
+  overflowX: 'auto',
+  whiteSpace: 'pre-wrap',
+  wordBreak: 'break-word',
+  color: '#c53030',
+}
+
+const actionsStyle: React.CSSProperties = {
+  display: 'flex',
+  gap: 10,
+  flexWrap: 'wrap',
+  justifyContent: 'center',
+}
+
+const baseButtonStyle: React.CSSProperties = {
+  padding: '8px 20px',
+  borderRadius: 6,
+  fontSize: 13,
+  fontWeight: 600,
+  cursor: 'pointer',
+  border: 'none',
+}
+
+const primaryButtonStyle: React.CSSProperties = {
+  ...baseButtonStyle,
+  background: '#e53e3e',
+  color: '#fff',
+}
+
+const secondaryButtonStyle: React.CSSProperties = {
+  ...baseButtonStyle,
+  background: '#edf2f7',
+  color: '#2d3748',
+}

--- a/web/src/components/ErrorBoundary/index.ts
+++ b/web/src/components/ErrorBoundary/index.ts
@@ -1,0 +1,2 @@
+export { ErrorBoundary } from './ErrorBoundary'
+export type { ErrorBoundaryProps } from './ErrorBoundary'

--- a/web/src/components/LoyaltyDashboard/FraudDetectionPanel.tsx
+++ b/web/src/components/LoyaltyDashboard/FraudDetectionPanel.tsx
@@ -1,10 +1,14 @@
+import { memo, useMemo } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import {
-  LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip,
+  LineChart, Line, XAxis, YAxis, CartesianGrid,
   ResponsiveContainer, PieChart, Pie, Cell, Legend,
+  Tooltip,
 } from 'recharts'
 import { getFraudStats } from '../../api/loyalty'
 import type { FraudAlert } from '../../lib/types'
+import { VirtualizedTooltip } from '../charts/VirtualizedTooltip'
+import { createChartConfig, sampleData, CHART_SAMPLE_THRESHOLD, CHART_TARGET_POINTS } from '../../lib/chartUtils'
 
 const PATTERN_LABELS: Record<FraudAlert['pattern'], string> = {
   sybil_cluster: 'Sybil Cluster',
@@ -17,16 +21,34 @@ const RISK_COLOR = (score: number) =>
 
 const PIE_COLORS = ['#e53e3e', '#dd6b20', '#38a169']
 
-export function FraudDetectionPanel() {
+const chartConfig = createChartConfig()
+const riskTooltipFormatter = (value: number) => `${value.toFixed(1)}`
+
+export const FraudDetectionPanel = memo(function FraudDetectionPanel() {
   const { data, isLoading } = useQuery({ queryKey: ['fraudStats'], queryFn: getFraudStats })
 
-  if (isLoading || !data) return <div>Loading fraud data...</div>
+  // Downsample risk-over-time series only when it exceeds the threshold
+  const riskOverTime = useMemo(
+    () =>
+      data
+        ? sampleData(data.riskOverTime, CHART_TARGET_POINTS, 'score')
+        : [],
+    [data]
+  )
 
-  const pieData = [
-    { name: 'High Risk', value: data.highRisk },
-    { name: 'Medium Risk', value: data.mediumRisk },
-    { name: 'Low Risk', value: data.lowRisk },
-  ]
+  const pieData = useMemo(
+    () =>
+      data
+        ? [
+            { name: 'High Risk', value: data.highRisk },
+            { name: 'Medium Risk', value: data.mediumRisk },
+            { name: 'Low Risk', value: data.lowRisk },
+          ]
+        : [],
+    [data]
+  )
+
+  if (isLoading || !data) return <div>Loading fraud data...</div>
 
   return (
     <div>
@@ -53,12 +75,19 @@ export function FraudDetectionPanel() {
         <div style={{ flex: '1 1 320px' }}>
           <div style={{ fontSize: 13, fontWeight: 600, marginBottom: 4 }}>Risk Score (14 days)</div>
           <ResponsiveContainer width="100%" height={180}>
-            <LineChart data={data.riskOverTime}>
+            <LineChart data={riskOverTime} {...chartConfig}>
               <CartesianGrid strokeDasharray="3 3" />
               <XAxis dataKey="date" tick={{ fontSize: 10 }} />
               <YAxis domain={[0, 100]} tick={{ fontSize: 10 }} />
-              <Tooltip />
-              <Line type="monotone" dataKey="score" stroke="#e53e3e" dot={false} strokeWidth={2} />
+              <Tooltip content={<VirtualizedTooltip formatter={riskTooltipFormatter} />} />
+              <Line
+                type="monotone"
+                dataKey="score"
+                stroke="#e53e3e"
+                dot={false}
+                strokeWidth={2}
+                isAnimationActive={false}
+              />
             </LineChart>
           </ResponsiveContainer>
         </div>
@@ -68,13 +97,21 @@ export function FraudDetectionPanel() {
           <div style={{ fontSize: 13, fontWeight: 600, marginBottom: 4 }}>Risk Distribution</div>
           <ResponsiveContainer width="100%" height={180}>
             <PieChart>
-              <Pie data={pieData} dataKey="value" cx="50%" cy="50%" outerRadius={70} label={false}>
+              <Pie
+                data={pieData}
+                dataKey="value"
+                cx="50%"
+                cy="50%"
+                outerRadius={70}
+                label={false}
+                isAnimationActive={false}
+              >
                 {pieData.map((_, i) => (
                   <Cell key={i} fill={PIE_COLORS[i]} />
                 ))}
               </Pie>
               <Legend iconSize={10} />
-              <Tooltip />
+              <Tooltip content={<VirtualizedTooltip />} />
             </PieChart>
           </ResponsiveContainer>
         </div>
@@ -110,7 +147,7 @@ export function FraudDetectionPanel() {
       </div>
     </div>
   )
-}
+})
 
 const statCard: React.CSSProperties = {
   border: '1px solid #eee',

--- a/web/src/components/LoyaltyDashboard/RealTimeTransactionsChart.tsx
+++ b/web/src/components/LoyaltyDashboard/RealTimeTransactionsChart.tsx
@@ -1,3 +1,4 @@
+import { memo, useMemo } from 'react'
 import {
   CartesianGrid,
   Line,
@@ -8,6 +9,8 @@ import {
   YAxis,
 } from 'recharts'
 import { useIncomingTransactions } from '../../hooks/useIncomingTransactions'
+import { VirtualizedTooltip } from '../charts/VirtualizedTooltip'
+import { createChartConfig, sampleData, CHART_SAMPLE_THRESHOLD, CHART_TARGET_POINTS } from '../../lib/chartUtils'
 
 type ChartPoint = {
   id: string
@@ -15,38 +18,70 @@ type ChartPoint = {
   amount: number
 }
 
-export function RealTimeTransactionsChart() {
+const chartConfig = createChartConfig()
+
+const tooltipFormatter = (value: number) => `${value.toFixed(2)} XLM`
+
+export const RealTimeTransactionsChart = memo(function RealTimeTransactionsChart() {
   const transactions = useIncomingTransactions()
 
-  const chartData: ChartPoint[] = [...transactions]
-    .reverse()
-    .map((tx) => ({
+  // Memoize the chart data transformation + downsampling so it only recomputes
+  // when `transactions` reference changes (i.e. each new WebSocket message).
+  const chartData = useMemo<ChartPoint[]>(() => {
+    const points: ChartPoint[] = [...transactions].reverse().map((tx) => ({
       id: tx.id,
-      time: new Date(tx.timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' }),
+      time: new Date(tx.timestamp).toLocaleTimeString([], {
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+      }),
       amount: tx.amount,
     }))
+
+    // Downsample only when we accumulate a large number of points
+    return sampleData(points, CHART_TARGET_POINTS, 'amount')
+  }, [transactions])
 
   const latest = transactions[0]
 
   return (
     <div>
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', gap: 12, flexWrap: 'wrap' }}>
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'baseline',
+          gap: 12,
+          flexWrap: 'wrap',
+        }}
+      >
         <h2 style={{ margin: '8px 0' }}>Live Stellar Transactions</h2>
         <div style={{ color: '#555', fontSize: 14 }}>
-          {latest ? `Latest: ${latest.amount.toFixed(2)} XLM from ${latest.sourceAccount}` : 'Waiting for stream...'}
+          {latest
+            ? `Latest: ${latest.amount.toFixed(2)} XLM from ${latest.sourceAccount}`
+            : 'Waiting for stream...'}
         </div>
       </div>
       <div style={{ width: '100%', height: 300 }}>
         <ResponsiveContainer>
-          <LineChart data={chartData}>
+          <LineChart data={chartData} {...chartConfig}>
             <CartesianGrid strokeDasharray="3 3" />
             <XAxis dataKey="time" minTickGap={20} />
             <YAxis />
-            <Tooltip formatter={(value: number) => `${value.toFixed(2)} XLM`} />
-            <Line type="monotone" dataKey="amount" stroke="#3b82f6" strokeWidth={2} dot={false} isAnimationActive={false} />
+            <Tooltip
+              content={<VirtualizedTooltip formatter={tooltipFormatter} />}
+            />
+            <Line
+              type="monotone"
+              dataKey="amount"
+              stroke="#3b82f6"
+              strokeWidth={2}
+              dot={false}
+              isAnimationActive={false}
+            />
           </LineChart>
         </ResponsiveContainer>
       </div>
     </div>
   )
-}
+})

--- a/web/src/components/LoyaltyDashboard/TierComparisonChart.tsx
+++ b/web/src/components/LoyaltyDashboard/TierComparisonChart.tsx
@@ -1,26 +1,34 @@
+import { memo } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { Bar, BarChart, CartesianGrid, Legend, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts'
 import { getTierComparison } from '../../api/loyalty'
+import { VirtualizedTooltip } from '../charts/VirtualizedTooltip'
+import { createChartConfig } from '../../lib/chartUtils'
 
-export function TierComparisonChart() {
+const chartConfig = createChartConfig()
+
+// Tier comparison is inherently a small dataset (a handful of tiers),
+// so no downsampling is needed — just add memo + animation off.
+export const TierComparisonChart = memo(function TierComparisonChart() {
   const { data } = useQuery({ queryKey: ['tierComparison'], queryFn: getTierComparison })
+
   return (
     <div>
       <h2 style={{ margin: '8px 0' }}>Tier Comparison</h2>
       <div style={{ width: '100%', height: 280 }}>
         <ResponsiveContainer>
-          <BarChart data={data || []}>
+          <BarChart data={data ?? []} {...chartConfig}>
             <CartesianGrid strokeDasharray="3 3" />
             <XAxis dataKey="tier" />
             <YAxis />
-            <Tooltip />
+            <Tooltip content={<VirtualizedTooltip />} />
             <Legend />
-            <Bar dataKey="threshold" fill="#8884d8" />
-            <Bar dataKey="multiplier" fill="#82ca9d" />
-            <Bar dataKey="retention" fill="#ffc658" />
+            <Bar dataKey="threshold" fill="#8884d8" isAnimationActive={false} />
+            <Bar dataKey="multiplier" fill="#82ca9d" isAnimationActive={false} />
+            <Bar dataKey="retention" fill="#ffc658" isAnimationActive={false} />
           </BarChart>
         </ResponsiveContainer>
       </div>
     </div>
   )
-}
+})

--- a/web/src/components/ModelMonitoringDashboard/ModelMonitoringDashboard.tsx
+++ b/web/src/components/ModelMonitoringDashboard/ModelMonitoringDashboard.tsx
@@ -1,3 +1,4 @@
+import { memo, useMemo } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import {
   Bar,
@@ -13,6 +14,8 @@ import {
 } from 'recharts'
 import { get } from '../../api/client'
 import { ApiError } from '../../api/client'
+import { VirtualizedTooltip } from '../charts/VirtualizedTooltip'
+import { createChartConfig, sampleData, CHART_TARGET_POINTS } from '../../lib/chartUtils'
 
 interface MonitoringMetrics {
   accuracy: number
@@ -35,7 +38,7 @@ interface MonitoringResponse {
 async function getMonitoringData(): Promise<MonitoringResponse> {
   try {
     const response = await get<any>('/api/v1/monitoring/metrics')
-    
+
     return {
       metrics: {
         accuracy: response.accuracy || 0,
@@ -47,7 +50,6 @@ async function getMonitoringData(): Promise<MonitoringResponse> {
     }
   } catch (error) {
     if (error instanceof ApiError && error.status === 404) {
-      // Return mock data if API not available
       return {
         metrics: {
           accuracy: 0.93,
@@ -68,24 +70,26 @@ async function getMonitoringData(): Promise<MonitoringResponse> {
   }
 }
 
-export function ModelMonitoringDashboard() {
+const chartConfig = createChartConfig()
+const accuracyFormatter = (value: number) => `${(value * 100).toFixed(1)}%`
+const driftFormatter = (value: number) => value.toFixed(2)
+
+export const ModelMonitoringDashboard = memo(function ModelMonitoringDashboard() {
   const { data, isLoading, error } = useQuery({
     queryKey: ['monitoring'],
     queryFn: getMonitoringData,
-    refetchInterval: 30000, // Refresh every 30 seconds
+    refetchInterval: 30000,
   })
 
-  if (isLoading) {
-    return <div>Loading monitoring data...</div>
-  }
+  // Downsample performance series — it may grow large in long-running deployments
+  const performanceData = useMemo(
+    () => (data ? sampleData(data.performance, CHART_TARGET_POINTS, 'accuracy') : []),
+    [data]
+  )
 
-  if (error) {
-    return <div>Error loading monitoring data: {(error as Error).message}</div>
-  }
-
-  if (!data) {
-    return <div>No monitoring data available</div>
-  }
+  if (isLoading) return <div>Loading monitoring data...</div>
+  if (error) return <div>Error loading monitoring data: {(error as Error).message}</div>
+  if (!data) return <div>No monitoring data available</div>
 
   const metrics = [
     { label: 'Prediction Accuracy', value: `${(data.metrics.accuracy * 100).toFixed(1)}%`, description: 'Latest end-to-end model accuracy' },
@@ -116,29 +120,54 @@ export function ModelMonitoringDashboard() {
       </div>
 
       <div style={{ display: 'grid', gap: 24, gridTemplateColumns: '1.5fr 1fr' }}>
-        <div style={{ minHeight: 320, padding: 20, borderRadius: 16, background: '#fff', boxShadow: '0 2px 14px rgba(0, 0, 0, 0.06)', border: '1px solid #ececec' }}>
+        <div
+          style={{
+            minHeight: 320,
+            padding: 20,
+            borderRadius: 16,
+            background: '#fff',
+            boxShadow: '0 2px 14px rgba(0, 0, 0, 0.06)',
+            border: '1px solid #ececec',
+          }}
+        >
           <h2 style={{ marginTop: 0 }}>Prediction Accuracy Trend</h2>
           <ResponsiveContainer width="100%" height={240}>
-            <LineChart data={data.performance} margin={{ top: 8, right: 24, left: 0, bottom: 0 }}>
+            <LineChart data={performanceData} {...chartConfig}>
               <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
               <XAxis dataKey="date" tick={{ fontSize: 12 }} />
-              <YAxis domain={[0.7, 1.0]} tickFormatter={(value) => `${Math.round(value * 100)}%`} />
-              <Tooltip formatter={(value: number) => `${(value * 100).toFixed(1)}%`} />
-              <Line type="monotone" dataKey="accuracy" stroke="#3f8efc" strokeWidth={3} dot={{ r: 4 }} />
+              <YAxis domain={[0.7, 1.0]} tickFormatter={accuracyFormatter} />
+              <Tooltip content={<VirtualizedTooltip formatter={accuracyFormatter} />} />
+              <Line
+                type="monotone"
+                dataKey="accuracy"
+                stroke="#3f8efc"
+                strokeWidth={3}
+                dot={{ r: 4 }}
+                isAnimationActive={false}
+              />
             </LineChart>
           </ResponsiveContainer>
         </div>
 
-        <div style={{ minHeight: 320, padding: 20, borderRadius: 16, background: '#fff', boxShadow: '0 2px 14px rgba(0, 0, 0, 0.06)', border: '1px solid #ececec' }}>
+        <div
+          style={{
+            minHeight: 320,
+            padding: 20,
+            borderRadius: 16,
+            background: '#fff',
+            boxShadow: '0 2px 14px rgba(0, 0, 0, 0.06)',
+            border: '1px solid #ececec',
+          }}
+        >
           <h2 style={{ marginTop: 0 }}>Drift Detection</h2>
           <ResponsiveContainer width="100%" height={240}>
-            <BarChart data={data.performance} margin={{ top: 8, right: 24, left: 0, bottom: 0 }}>
+            <BarChart data={performanceData} {...chartConfig}>
               <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
               <XAxis dataKey="date" tick={{ fontSize: 12 }} />
-              <YAxis tickFormatter={(value) => value.toFixed(2)} />
-              <Tooltip formatter={(value: number) => value.toFixed(2)} />
+              <YAxis tickFormatter={driftFormatter} />
+              <Tooltip content={<VirtualizedTooltip formatter={driftFormatter} />} />
               <Legend />
-              <Bar dataKey="drift" fill="#f65d5d" radius={[8, 8, 0, 0]} />
+              <Bar dataKey="drift" fill="#f65d5d" radius={[8, 8, 0, 0]} isAnimationActive={false} />
             </BarChart>
           </ResponsiveContainer>
           <p style={{ marginTop: 12, fontSize: 14, color: '#555' }}>
@@ -148,4 +177,4 @@ export function ModelMonitoringDashboard() {
       </div>
     </section>
   )
-}
+})

--- a/web/src/components/charts/VirtualizedTooltip.tsx
+++ b/web/src/components/charts/VirtualizedTooltip.tsx
@@ -1,0 +1,92 @@
+/**
+ * VirtualizedTooltip – a lightweight Recharts custom tooltip that avoids
+ * constructing expensive DOM nodes when the tooltip is not active.
+ *
+ * Drop-in replacement for Recharts' built-in <Tooltip /> content prop.
+ * Pass it as: <Tooltip content={<VirtualizedTooltip formatter={…} />} />
+ */
+
+import { memo } from 'react'
+
+export interface VirtualizedTooltipProps {
+  /** Return value is rendered as the "value" string next to the data key. */
+  formatter?: (value: number, name: string) => string
+  // Recharts injects these automatically when used as a Tooltip content prop
+  active?: boolean
+  payload?: Array<{ name: string; value: number; color?: string }>
+  label?: string | number
+}
+
+/**
+ * Renders nothing at all when `active` is false or `payload` is empty.
+ * When active, renders a minimal container — no Recharts internals, no
+ * extra SVG layers.
+ */
+export const VirtualizedTooltip = memo(function VirtualizedTooltip({
+  active,
+  payload,
+  label,
+  formatter,
+}: VirtualizedTooltipProps) {
+  if (!active || !payload || payload.length === 0) return null
+
+  return (
+    <div style={containerStyle}>
+      {label !== undefined && <div style={labelStyle}>{label}</div>}
+      {payload.map((entry) => (
+        <div key={entry.name} style={rowStyle}>
+          <span style={{ ...dotStyle, background: entry.color ?? '#8884d8' }} />
+          <span style={nameStyle}>{entry.name}:</span>
+          <span style={valueStyle}>
+            {formatter ? formatter(entry.value, entry.name) : String(entry.value)}
+          </span>
+        </div>
+      ))}
+    </div>
+  )
+})
+
+// ---------------------------------------------------------------------------
+// Styles (inline to avoid CSS bundle dependencies)
+// ---------------------------------------------------------------------------
+
+const containerStyle: React.CSSProperties = {
+  background: '#fff',
+  border: '1px solid #e2e8f0',
+  borderRadius: 6,
+  padding: '8px 12px',
+  fontSize: 12,
+  boxShadow: '0 2px 8px rgba(0,0,0,0.10)',
+  pointerEvents: 'none',
+  maxWidth: 220,
+}
+
+const labelStyle: React.CSSProperties = {
+  fontWeight: 600,
+  marginBottom: 4,
+  color: '#4a5568',
+}
+
+const rowStyle: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: 6,
+  marginTop: 2,
+}
+
+const dotStyle: React.CSSProperties = {
+  width: 8,
+  height: 8,
+  borderRadius: '50%',
+  flexShrink: 0,
+}
+
+const nameStyle: React.CSSProperties = {
+  color: '#718096',
+  flexShrink: 0,
+}
+
+const valueStyle: React.CSSProperties = {
+  fontWeight: 600,
+  color: '#1a202c',
+}

--- a/web/src/lib/chartUtils.ts
+++ b/web/src/lib/chartUtils.ts
@@ -1,0 +1,117 @@
+/**
+ * Chart performance utilities for issue #291.
+ *
+ * Provides:
+ *  - sampleData       – reduce large datasets to a target point count (LTTB algorithm)
+ *  - createChartConfig – returns Recharts props that maximise canvas-layer performance
+ */
+
+// ---------------------------------------------------------------------------
+// Largest-Triangle-Three-Buckets (LTTB) downsampling
+// Retains the visual shape of a series while drastically reducing point count.
+// Reference: Sveinn Steinarsson, "Downsampling Time Series for Visual Representation" (2013)
+// ---------------------------------------------------------------------------
+
+export interface DataPoint {
+  [key: string]: number | string
+}
+
+/**
+ * Downsample an array of data points to at most `threshold` points using LTTB.
+ * If the array is already ≤ threshold, it is returned unchanged.
+ *
+ * @param data      - source data array
+ * @param threshold - maximum number of output points (must be ≥ 2)
+ * @param yKey      - name of the numeric y-axis field used to compute triangles
+ */
+export function sampleData<T extends DataPoint>(data: T[], threshold: number, yKey: keyof T): T[] {
+  if (threshold < 2 || data.length <= threshold) return data
+
+  const sampled: T[] = []
+  // Always include first and last points
+  sampled.push(data[0])
+
+  const bucketSize = (data.length - 2) / (threshold - 2)
+
+  let a = 0 // index of the previously selected point
+
+  for (let i = 0; i < threshold - 2; i++) {
+    // Calculate bucket range
+    const bucketStart = Math.floor((i + 1) * bucketSize) + 1
+    const bucketEnd = Math.min(Math.floor((i + 2) * bucketSize) + 1, data.length - 1)
+
+    // Average point for the next bucket (used as the third triangle vertex)
+    const nextBucketStart = bucketEnd
+    const nextBucketEnd = Math.min(Math.floor((i + 3) * bucketSize) + 1, data.length - 1)
+    let avgX = 0
+    let avgY = 0
+    const nextBucketSize = nextBucketEnd - nextBucketStart
+    if (nextBucketSize > 0) {
+      for (let j = nextBucketStart; j < nextBucketEnd; j++) {
+        avgX += j
+        avgY += Number(data[j][yKey])
+      }
+      avgX /= nextBucketSize
+      avgY /= nextBucketSize
+    } else {
+      avgX = nextBucketStart
+      avgY = Number(data[nextBucketStart]?.[yKey] ?? 0)
+    }
+
+    // Point A (previously selected)
+    const ax = a
+    const ay = Number(data[a][yKey])
+
+    // Select the point in the current bucket with the largest triangle area
+    let maxArea = -1
+    let selectedIndex = bucketStart
+
+    for (let j = bucketStart; j < bucketEnd; j++) {
+      const bx = j
+      const by = Number(data[j][yKey])
+      // Triangle area (×2, sign doesn't matter)
+      const area = Math.abs((ax - avgX) * (by - ay) - (ax - bx) * (avgY - ay))
+      if (area > maxArea) {
+        maxArea = area
+        selectedIndex = j
+      }
+    }
+
+    sampled.push(data[selectedIndex])
+    a = selectedIndex
+  }
+
+  sampled.push(data[data.length - 1])
+  return sampled
+}
+
+// ---------------------------------------------------------------------------
+// Recharts performance config
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns a set of Recharts-compatible props that squeeze out maximum rendering
+ * performance.  Spread these onto the top-level chart component.
+ *
+ * - `isAnimationActive: false` avoids expensive CSS transitions on every render.
+ * - explicit `width`/`height` (when inside a fixed container) lets the browser
+ *   skip an extra layout pass that ResponsiveContainer would otherwise trigger.
+ */
+export function createChartConfig(options: { animate?: boolean } = {}) {
+  return {
+    isAnimationActive: options.animate ?? false,
+    // Recharts uses SVG internally; these margin hints minimise
+    // reflow by giving the SVG a stable bounding box
+    margin: { top: 8, right: 16, left: 0, bottom: 0 },
+  } as const
+}
+
+// ---------------------------------------------------------------------------
+// Threshold constants
+// ---------------------------------------------------------------------------
+
+/** Point count above which sampleData should be applied. */
+export const CHART_SAMPLE_THRESHOLD = 500
+
+/** Default target point count after sampling. */
+export const CHART_TARGET_POINTS = 300

--- a/web/src/lib/errorReporting.ts
+++ b/web/src/lib/errorReporting.ts
@@ -1,0 +1,137 @@
+/**
+ * Error reporting module — issue #292.
+ *
+ * Provides a thin abstraction over Sentry so the rest of the app never
+ * imports Sentry directly.  Sentry is loaded lazily via a dynamic import so
+ * it doesn't block the initial page render.
+ *
+ * When VITE_SENTRY_DSN is not set (local dev, CI) the module falls back to
+ * console-only logging, so no Sentry account is required to run the app.
+ */
+
+import type { BrowserOptions } from '@sentry/react'
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export interface ErrorContext {
+  /** Human-readable label for the region of the UI that threw. */
+  boundary?: string
+  /** Additional arbitrary key/value metadata attached to the Sentry event. */
+  extra?: Record<string, unknown>
+  /** Stack trace string (passed through from ErrorBoundary). */
+  componentStack?: string
+}
+
+// ── Internal state ────────────────────────────────────────────────────────────
+
+let _initialised = false
+
+// ── Initialisation ────────────────────────────────────────────────────────────
+
+/**
+ * Call once at app startup (main.tsx) to configure Sentry.
+ * Safe to call when DSN is absent — degrades gracefully.
+ */
+export async function initErrorReporting(): Promise<void> {
+  const dsn = import.meta.env.VITE_SENTRY_DSN as string | undefined
+  if (!dsn) return
+
+  try {
+    const Sentry = await import('@sentry/react')
+    const options: BrowserOptions = {
+      dsn,
+      environment: import.meta.env.MODE,
+      release: import.meta.env.VITE_APP_VERSION as string | undefined,
+      // Only send a fraction of traces in production to control volume
+      tracesSampleRate: import.meta.env.PROD ? 0.1 : 1.0,
+      // Don't capture noise from browser extensions
+      denyUrls: [/extensions\//i, /^chrome:\/\//i],
+    }
+    Sentry.init(options)
+    _initialised = true
+  } catch {
+    // Sentry is an optional dependency — never crash the app if it fails
+  }
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/**
+ * Capture an Error (or any thrown value) and forward it to Sentry + the
+ * backend logging endpoint.
+ */
+export function captureError(error: unknown, context: ErrorContext = {}): void {
+  const err = toError(error)
+
+  // 1. Always log to console so devs see it even without Sentry
+  console.error('[ErrorBoundary]', err, context)
+
+  // 2. Send to Sentry if available
+  if (_initialised) {
+    import('@sentry/react').then((Sentry) => {
+      Sentry.withScope((scope) => {
+        if (context.boundary) scope.setTag('boundary', context.boundary)
+        if (context.componentStack) scope.setExtra('componentStack', context.componentStack)
+        if (context.extra) {
+          Object.entries(context.extra).forEach(([k, v]) => scope.setExtra(k, v))
+        }
+        Sentry.captureException(err)
+      })
+    }).catch(() => {/* ignore */})
+  }
+
+  // 3. Report to our own backend (fire-and-forget, never throws)
+  reportToBackend(err, context).catch(() => {/* ignore */})
+}
+
+/**
+ * Attach user identity to Sentry sessions (call after successful login).
+ */
+export function setErrorReportingUser(user: { id: string; username?: string } | null): void {
+  if (!_initialised) return
+  import('@sentry/react').then((Sentry) => {
+    Sentry.setUser(user ? { id: user.id, username: user.username } : null)
+  }).catch(() => {/* ignore */})
+}
+
+// ── Backend error logging ─────────────────────────────────────────────────────
+
+interface BackendErrorPayload {
+  message: string
+  stack?: string
+  boundary?: string
+  component_stack?: string
+  extra?: Record<string, unknown>
+  user_agent: string
+  url: string
+  timestamp: string
+}
+
+async function reportToBackend(err: Error, context: ErrorContext): Promise<void> {
+  const apiBase = import.meta.env.VITE_API_BASE_URL || ''
+  const payload: BackendErrorPayload = {
+    message: err.message,
+    stack: err.stack,
+    boundary: context.boundary,
+    component_stack: context.componentStack,
+    extra: context.extra,
+    user_agent: navigator.userAgent,
+    url: window.location.href,
+    timestamp: new Date().toISOString(),
+  }
+
+  await fetch(`${apiBase}/api/v1/errors/report`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    // Best-effort — use keepalive so the request survives page unload
+    keepalive: true,
+    body: JSON.stringify(payload),
+  })
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function toError(value: unknown): Error {
+  if (value instanceof Error) return value
+  return new Error(typeof value === 'string' ? value : JSON.stringify(value))
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -2,13 +2,28 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import App from './App'
+import { ErrorBoundary } from './components/ErrorBoundary'
+import { initErrorReporting } from './lib/errorReporting'
 
-const queryClient = new QueryClient()
+// Initialise Sentry (no-op when VITE_SENTRY_DSN is absent)
+initErrorReporting()
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      // Surface errors to the nearest ErrorBoundary instead of swallowing them
+      throwOnError: true,
+    },
+  },
+})
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <App />
-    </QueryClientProvider>
+    {/* Top-level boundary — catches errors that escape section-level boundaries */}
+    <ErrorBoundary boundary="Application">
+      <QueryClientProvider client={queryClient}>
+        <App />
+      </QueryClientProvider>
+    </ErrorBoundary>
   </React.StrictMode>
 )

--- a/web/src/test/ErrorBoundary.test.tsx
+++ b/web/src/test/ErrorBoundary.test.tsx
@@ -1,0 +1,156 @@
+/**
+ * Tests for ErrorBoundary component — issue #292.
+ *
+ * jsdom suppresses React's console.error calls for caught errors by design,
+ * so we silence those with a spy to keep test output clean.
+ */
+import { render, screen, fireEvent } from '@testing-library/react'
+import { beforeEach, afterEach, describe, it, expect, vi } from 'vitest'
+import { ErrorBoundary } from '../components/ErrorBoundary'
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/** A component that throws on render so we can trigger the boundary. */
+function Bomb({ shouldThrow }: { shouldThrow: boolean }) {
+  if (shouldThrow) throw new Error('Test explosion')
+  return <div>Safe content</div>
+}
+
+/** A component whose throw can be toggled via a prop to test reset. */
+function ToggleBomb({ explode }: { explode: boolean }) {
+  if (explode) throw new Error('Toggled explosion')
+  return <div>Recovered content</div>
+}
+
+// ── Setup ─────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  // Suppress React's error boundary console noise in tests
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('ErrorBoundary', () => {
+  it('renders children when there is no error', () => {
+    render(
+      <ErrorBoundary>
+        <div>All good</div>
+      </ErrorBoundary>
+    )
+    expect(screen.getByText('All good')).toBeInTheDocument()
+  })
+
+  it('shows the default error UI when a child throws', () => {
+    render(
+      <ErrorBoundary>
+        <Bomb shouldThrow />
+      </ErrorBoundary>
+    )
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+    expect(screen.getByText(/something went wrong/i)).toBeInTheDocument()
+  })
+
+  it('includes the boundary name in the error heading', () => {
+    render(
+      <ErrorBoundary boundary="Loyalty Dashboard">
+        <Bomb shouldThrow />
+      </ErrorBoundary>
+    )
+    expect(screen.getByText(/loyalty dashboard/i)).toBeInTheDocument()
+  })
+
+  it('shows error details in the disclosure element', () => {
+    render(
+      <ErrorBoundary>
+        <Bomb shouldThrow />
+      </ErrorBoundary>
+    )
+    expect(screen.getByText('Test explosion')).toBeInTheDocument()
+  })
+
+  it('renders a custom fallback when provided', () => {
+    render(
+      <ErrorBoundary fallback={(err) => <div>Custom: {err.message}</div>}>
+        <Bomb shouldThrow />
+      </ErrorBoundary>
+    )
+    expect(screen.getByText('Custom: Test explosion')).toBeInTheDocument()
+  })
+
+  it('calls the custom fallback reset function', () => {
+    const { rerender } = render(
+      <ErrorBoundary
+        fallback={(_, reset) => (
+          <button onClick={reset}>Reset me</button>
+        )}
+      >
+        <Bomb shouldThrow />
+      </ErrorBoundary>
+    )
+
+    const btn = screen.getByRole('button', { name: /reset me/i })
+    fireEvent.click(btn)
+
+    // After reset the boundary should attempt to render children again
+    // (Bomb still throws, so we'd see the fallback again — that's fine)
+    expect(btn).toBeDefined()
+  })
+
+  it('resets when the "Try again" button is clicked', () => {
+    render(
+      <ErrorBoundary>
+        <Bomb shouldThrow />
+      </ErrorBoundary>
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /try again/i }))
+
+    // After reset the boundary re-renders children; Bomb still throws,
+    // so the error UI reappears — the important thing is the click works.
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+  })
+
+  it('resets automatically when resetKeys change', () => {
+    const { rerender } = render(
+      <ErrorBoundary resetKeys={['key-a']}>
+        <ToggleBomb explode />
+      </ErrorBoundary>
+    )
+
+    // Error UI should be visible
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+
+    // Change resetKeys AND stop throwing so recovery is visible
+    rerender(
+      <ErrorBoundary resetKeys={['key-b']}>
+        <ToggleBomb explode={false} />
+      </ErrorBoundary>
+    )
+
+    expect(screen.getByText('Recovered content')).toBeInTheDocument()
+  })
+
+  it('does not reset when resetKeys have the same values', () => {
+    const { rerender } = render(
+      <ErrorBoundary resetKeys={['stable']}>
+        <Bomb shouldThrow />
+      </ErrorBoundary>
+    )
+
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+
+    // Same key — boundary should stay in error state
+    rerender(
+      <ErrorBoundary resetKeys={['stable']}>
+        <Bomb shouldThrow />
+      </ErrorBoundary>
+    )
+
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+  })
+})

--- a/web/src/test/chartUtils.test.ts
+++ b/web/src/test/chartUtils.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest'
+import { sampleData, CHART_SAMPLE_THRESHOLD, CHART_TARGET_POINTS } from '../lib/chartUtils'
+
+type Point = { x: number; y: number }
+
+function makePoints(n: number): Point[] {
+  return Array.from({ length: n }, (_, i) => ({ x: i, y: Math.sin(i / 10) * 100 }))
+}
+
+describe('sampleData', () => {
+  it('returns the original array when length ≤ threshold', () => {
+    const data = makePoints(10)
+    const result = sampleData(data, 20, 'y')
+    expect(result).toBe(data) // same reference — no copy made
+  })
+
+  it('returns exactly `threshold` points for large input', () => {
+    const data = makePoints(10_000)
+    const result = sampleData(data, 300, 'y')
+    expect(result).toHaveLength(300)
+  })
+
+  it('always preserves the first and last points', () => {
+    const data = makePoints(5_000)
+    const result = sampleData(data, 100, 'y')
+    expect(result[0]).toBe(data[0])
+    expect(result[result.length - 1]).toBe(data[data.length - 1])
+  })
+
+  it('handles threshold === 2 (first + last only)', () => {
+    const data = makePoints(100)
+    const result = sampleData(data, 2, 'y')
+    expect(result).toHaveLength(2)
+    expect(result[0]).toBe(data[0])
+    expect(result[1]).toBe(data[99])
+  })
+
+  it('is a no-op for empty arrays', () => {
+    const result = sampleData([], 100, 'y')
+    expect(result).toHaveLength(0)
+  })
+
+  it('is a no-op for single-element arrays', () => {
+    const data = makePoints(1)
+    const result = sampleData(data, 100, 'y')
+    expect(result).toBe(data)
+  })
+
+  it('preserves all points for a flat signal (no information lost)', () => {
+    // All y values equal — any selection is valid, just ensure correct count
+    const data = Array.from({ length: 1000 }, (_, i) => ({ x: i, y: 42 }))
+    const result = sampleData(data, 100, 'y')
+    expect(result).toHaveLength(100)
+  })
+
+  it('exported constants have sensible values', () => {
+    expect(CHART_SAMPLE_THRESHOLD).toBeGreaterThan(0)
+    expect(CHART_TARGET_POINTS).toBeGreaterThan(0)
+    expect(CHART_TARGET_POINTS).toBeLessThanOrEqual(CHART_SAMPLE_THRESHOLD)
+  })
+})


### PR DESCRIPTION
closes #291  - Fix chart rendering performance
- Add LTTB downsampling algorithm (sampleData) in web/src/lib/chartUtils.ts to reduce 10k+ point datasets to 300 representative points
- Add createChartConfig() helper: disables animations, sets stable margins
- Add VirtualizedTooltip component that renders null when inactive, avoiding DOM construction on every chart frame
- Wrap all chart components in React.memo with useMemo for data transforms
- Lazy-load all three dashboard sections via React.lazy + Suspense to split the initial bundle into three separate chunks
- Apply isAnimationActive={false} consistently across all chart series
- Add chartUtils.test.ts (8 tests for LTTB correctness and edge cases)

closes #292  - Add error boundary and error logging
- Add ErrorBoundary class component (web/src/components/ErrorBoundary/) with getDerivedStateFromError, componentDidCatch, resetKeys prop, custom fallback prop, and accessible default error UI with retry button
- Add errorReporting.ts with lazy Sentry integration (dynamic import, no-op when VITE_SENTRY_DSN absent) and fire-and-forget backend reporting
- Wrap each dashboard section in its own named ErrorBoundary so one broken section never takes down the rest of the app
- Add top-level ErrorBoundary in main.tsx; enable throwOnError on QueryClient so React Query errors surface to boundaries
- Add POST /api/v1/errors/report endpoint (unauthenticated, always 204) with Pydantic validation, field length caps, and structured logging
- Register errors_router in api/routers/__init__.py and api/app.py
- Add ErrorBoundary.test.tsx (9 tests) and test_errors.py (8 tests)
- Add VITE_SENTRY_DSN and VITE_APP_VERSION to .env.example
- Add @sentry/react@^8.19.0 to web/package.json