### PR TITLE
feat: add Pydantic settings config, GET /api/v1 version endpoint, and make run-api

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help quickstart test test-api lint format clean install
+.PHONY: help quickstart test test-api lint format clean install run-api
 
 help:
 	@echo "AstroML Development Commands"
@@ -12,6 +12,7 @@ help:
 	@echo "make format              Format code (black, isort)"
 	@echo "make install             Install development dependencies"
 	@echo "make clean               Clean build artifacts and cache"
+	@echo "make run-api             Start the FastAPI dev server on localhost:8000"
 	@echo ""
 
 quickstart:
@@ -33,6 +34,9 @@ lint:
 format:
 	black astroml/ tests/
 	isort astroml/ tests/
+
+run-api:
+	uvicorn api.app:app --host 0.0.0.0 --port 8000 --reload
 
 install:
 	pip install -e ".[dev]"

--- a/api/app.py
+++ b/api/app.py
@@ -27,6 +27,7 @@ from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 
 from api.auth.middleware import AuthMiddleware
+from api.config import settings
 from api.database import get_async_session_factory
 from api.routers import (
     accounts_router,
@@ -138,3 +139,8 @@ app.include_router(ws_router)
 @app.get("/health", tags=["ops"])
 async def health():
     return {"status": "ok"}
+
+
+@app.get("/api/v1", tags=["ops"])
+async def api_root():
+    return {"version": settings.api_version, "status": "ok"}

--- a/api/config.py
+++ b/api/config.py
@@ -1,0 +1,34 @@
+"""Application configuration loaded from environment variables / .env file."""
+from __future__ import annotations
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8", extra="ignore")
+
+    # Database
+    database_url: str = "sqlite+aiosqlite:///./astroml.db"
+
+    # API
+    api_host: str = "0.0.0.0"
+    api_port: int = 8000
+    api_reload: bool = False
+    api_version: str = "1.0.0"
+
+    # CORS — allow Vite dev server by default
+    cors_origins: list[str] = ["http://localhost:5173", "http://localhost:3000"]
+
+    # Auth
+    secret_key: str = "change-me-in-production"
+    access_token_expire_minutes: int = 60
+
+    # ML model paths
+    model_path: str = "outputs/model.pkl"
+    benchmark_results_dir: str = "benchmark_results"
+
+    # Logging
+    log_level: str = "INFO"
+
+
+settings = Settings()


### PR DESCRIPTION
## Summary

- Add `api/config.py` with `Settings` class (`pydantic-settings` `BaseSettings`) loading from environment variables and `.env` file — covers database URL, CORS origins, auth, model paths, and logging
- Wire `settings` into `api/app.py`; add `GET /api/v1` root endpoint returning `{"version": "...", "status": "ok"}`
- Add `make run-api` target: `uvicorn api.app:app --host 0.0.0.0 --port 8000 --reload`
- `GET /health` was already present and returns `{"status": "ok"}`

## Test plan

- [ ] `uvicorn api.app:app --reload` starts without errors
- [ ] `GET /health` returns 200 `{"status": "ok"}`
- [ ] `GET /api/v1` returns 200 with `version` and `status` fields
- [ ] CORS headers allow requests from `http://localhost:5173`
- [ ] `make run-api` launches the server

Closes Traqora/astroml#230