### PR TITLE
feat: implement contributor onboarding checklist with progress tracking

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -38,6 +38,7 @@ from api.routers import (
     models_router,
     monitoring_router,
     notifications_router,
+    onboarding_router,
     transactions_router,
     ws_router,
 )
@@ -132,6 +133,7 @@ app.include_router(loyalty_router)
 app.include_router(models_router)
 app.include_router(mentorship_router)
 app.include_router(notifications_router)
+app.include_router(onboarding_router)
 app.include_router(ws_router)
 
 

--- a/api/routers/__init__.py
+++ b/api/routers/__init__.py
@@ -9,6 +9,7 @@ from api.routers.models import router as models_router
 from api.routers.monitoring import router as monitoring_router
 from api.routers.notifications import router as notifications_router
 from api.routers.transactions import router as transactions_router
+from api.routers.onboarding import router as onboarding_router
 from api.routers.ws import router as ws_router
 
 __all__ = [
@@ -21,6 +22,7 @@ __all__ = [
     "models_router",
     "monitoring_router",
     "notifications_router",
+    "onboarding_router",
     "transactions_router",
     "ws_router",
 ]

--- a/api/routers/onboarding.py
+++ b/api/routers/onboarding.py
@@ -1,0 +1,55 @@
+"""Contributor onboarding checklist API — Issue #281."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi import APIRouter, HTTPException
+
+from api.schemas import OnboardingProgressOut, OnboardingStepIn
+from astroml.contributors.onboarding import ONBOARDING_STEPS, OnboardingTracker
+
+router = APIRouter(prefix="/api/v1/contributors", tags=["contributors"])
+
+_tracker = OnboardingTracker(store_path=Path("data/onboarding_progress.json"))
+
+
+@router.get("/onboarding/{github_username}", response_model=OnboardingProgressOut)
+def get_onboarding_progress(github_username: str):
+    """Return the onboarding checklist and progress for a contributor."""
+    progress = _tracker.get(github_username)
+    return _to_out(progress)
+
+
+@router.post("/onboarding/{github_username}/complete", response_model=OnboardingProgressOut)
+def complete_step(github_username: str, body: OnboardingStepIn):
+    """Mark an onboarding step as completed."""
+    try:
+        progress = _tracker.complete_step(github_username, body.step)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    return _to_out(progress)
+
+
+@router.delete("/onboarding/{github_username}", status_code=204)
+def reset_onboarding(github_username: str):
+    """Reset a contributor's onboarding progress."""
+    _tracker.reset(github_username)
+
+
+@router.get("/onboarding", response_model=list[OnboardingProgressOut])
+def list_all_progress():
+    """Return onboarding progress for all contributors."""
+    return [_to_out(p) for p in _tracker.all_progress()]
+
+
+def _to_out(progress) -> OnboardingProgressOut:
+    return OnboardingProgressOut(
+        github_username=progress.github_username,
+        checklist=progress.checklist(),
+        completed_count=len(progress.completed_steps),
+        total_steps=progress.total_steps,
+        progress_pct=progress.progress_pct,
+        is_complete=progress.is_complete,
+        started_at=progress.started_at,
+        last_updated=progress.last_updated,
+    )

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -431,3 +431,26 @@ class DigestEmailOut(BaseModel):
     period: str
     notifications_count: int
     generated_at: datetime
+
+
+# ─── Onboarding ────────────────────────────────────────────────────────────
+
+class OnboardingStepIn(BaseModel):
+    step: str
+
+
+class OnboardingChecklistItem(BaseModel):
+    step: str
+    label: str
+    completed: bool
+
+
+class OnboardingProgressOut(BaseModel):
+    github_username: str
+    checklist: List[OnboardingChecklistItem]
+    completed_count: int
+    total_steps: int
+    progress_pct: int
+    is_complete: bool
+    started_at: str
+    last_updated: str

--- a/api/tests/test_onboarding.py
+++ b/api/tests/test_onboarding.py
@@ -1,0 +1,59 @@
+"""Tests for contributor onboarding checklist endpoints — Issue #281."""
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.xdist_group("api_onboarding")
+class TestOnboardingProgress:
+    def test_get_new_contributor_returns_empty_checklist(self, client):
+        resp = client.get("/api/v1/contributors/onboarding/test_user_xyz")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["github_username"] == "test_user_xyz"
+        assert data["completed_count"] == 0
+        assert data["is_complete"] is False
+        assert isinstance(data["checklist"], list)
+        assert len(data["checklist"]) == 4
+
+    def test_checklist_items_have_required_fields(self, client):
+        data = client.get("/api/v1/contributors/onboarding/test_user_xyz").json()
+        for item in data["checklist"]:
+            assert "step" in item
+            assert "label" in item
+            assert "completed" in item
+            assert item["completed"] is False
+
+    def test_complete_step_marks_it_done(self, client):
+        resp = client.post(
+            "/api/v1/contributors/onboarding/test_user_abc/complete",
+            json={"step": "fork_repo"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["completed_count"] == 1
+        fork_item = next(i for i in data["checklist"] if i["step"] == "fork_repo")
+        assert fork_item["completed"] is True
+
+    def test_complete_unknown_step_returns_422(self, client):
+        resp = client.post(
+            "/api/v1/contributors/onboarding/test_user_abc/complete",
+            json={"step": "nonexistent_step"},
+        )
+        assert resp.status_code == 422
+
+    def test_progress_pct_increases_with_steps(self, client):
+        username = "test_pct_user"
+        for step in ["fork_repo", "setup_dev_environment", "run_tests", "first_pr"]:
+            client.post(
+                f"/api/v1/contributors/onboarding/{username}/complete",
+                json={"step": step},
+            )
+        data = client.get(f"/api/v1/contributors/onboarding/{username}").json()
+        assert data["progress_pct"] == 100
+        assert data["is_complete"] is True
+
+    def test_list_all_returns_list(self, client):
+        resp = client.get("/api/v1/contributors/onboarding")
+        assert resp.status_code == 200
+        assert isinstance(resp.json(), list)

--- a/astroml/contributors/onboarding.py
+++ b/astroml/contributors/onboarding.py
@@ -1,0 +1,130 @@
+"""Contributor onboarding checklist module.
+
+Tracks a new contributor's progress through the onboarding steps:
+  1. Fork the repository
+  2. Set up the development environment
+  3. Run the test suite
+  4. Open a first pull request
+
+Progress is stored per GitHub username and persisted to a JSON file.
+"""
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, field, asdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List, Optional
+
+ONBOARDING_STEPS: List[str] = [
+    "fork_repo",
+    "setup_dev_environment",
+    "run_tests",
+    "first_pr",
+]
+
+STEP_LABELS: Dict[str, str] = {
+    "fork_repo": "Fork the repository",
+    "setup_dev_environment": "Set up dev environment",
+    "run_tests": "Run the test suite",
+    "first_pr": "Open your first pull request",
+}
+
+_DEFAULT_STORE = Path(os.environ.get("ONBOARDING_STORE", "data/onboarding_progress.json"))
+
+
+@dataclass
+class OnboardingProgress:
+    github_username: str
+    completed_steps: List[str] = field(default_factory=list)
+    started_at: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+    last_updated: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+
+    @property
+    def total_steps(self) -> int:
+        return len(ONBOARDING_STEPS)
+
+    @property
+    def progress_pct(self) -> int:
+        if not self.total_steps:
+            return 0
+        return round(len(self.completed_steps) / self.total_steps * 100)
+
+    @property
+    def is_complete(self) -> bool:
+        return set(ONBOARDING_STEPS).issubset(set(self.completed_steps))
+
+    def remaining_steps(self) -> List[str]:
+        done = set(self.completed_steps)
+        return [s for s in ONBOARDING_STEPS if s not in done]
+
+    def checklist(self) -> List[Dict[str, object]]:
+        done = set(self.completed_steps)
+        return [
+            {"step": step, "label": STEP_LABELS[step], "completed": step in done}
+            for step in ONBOARDING_STEPS
+        ]
+
+
+class OnboardingTracker:
+    """Persists and retrieves onboarding progress per contributor."""
+
+    def __init__(self, store_path: Path = _DEFAULT_STORE) -> None:
+        self._path = store_path
+
+    def _load(self) -> Dict[str, dict]:
+        if not self._path.exists():
+            return {}
+        try:
+            return json.loads(self._path.read_text())
+        except (json.JSONDecodeError, OSError):
+            return {}
+
+    def _save(self, data: Dict[str, dict]) -> None:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._path.write_text(json.dumps(data, indent=2))
+
+    def get(self, github_username: str) -> OnboardingProgress:
+        data = self._load()
+        raw = data.get(github_username)
+        if not raw:
+            return OnboardingProgress(github_username=github_username)
+        return OnboardingProgress(
+            github_username=raw["github_username"],
+            completed_steps=raw.get("completed_steps", []),
+            started_at=raw.get("started_at", datetime.now(timezone.utc).isoformat()),
+            last_updated=raw.get("last_updated", datetime.now(timezone.utc).isoformat()),
+        )
+
+    def complete_step(self, github_username: str, step: str) -> OnboardingProgress:
+        if step not in ONBOARDING_STEPS:
+            raise ValueError(f"Unknown onboarding step: {step!r}. Valid steps: {ONBOARDING_STEPS}")
+
+        progress = self.get(github_username)
+        if step not in progress.completed_steps:
+            progress.completed_steps.append(step)
+            progress.last_updated = datetime.now(timezone.utc).isoformat()
+
+        data = self._load()
+        data[github_username] = asdict(progress)
+        self._save(data)
+        return progress
+
+    def reset(self, github_username: str) -> OnboardingProgress:
+        data = self._load()
+        data.pop(github_username, None)
+        self._save(data)
+        return OnboardingProgress(github_username=github_username)
+
+    def all_progress(self) -> List[OnboardingProgress]:
+        data = self._load()
+        return [
+            OnboardingProgress(
+                github_username=v["github_username"],
+                completed_steps=v.get("completed_steps", []),
+                started_at=v.get("started_at", ""),
+                last_updated=v.get("last_updated", ""),
+            )
+            for v in data.values()
+        ]

--- a/web/src/components/OnboardingChecklist/OnboardingChecklist.tsx
+++ b/web/src/components/OnboardingChecklist/OnboardingChecklist.tsx
@@ -1,0 +1,101 @@
+import { useEffect, useState } from "react";
+
+interface ChecklistItem {
+  step: string;
+  label: string;
+  completed: boolean;
+}
+
+interface OnboardingProgress {
+  github_username: string;
+  checklist: ChecklistItem[];
+  completed_count: number;
+  total_steps: number;
+  progress_pct: number;
+  is_complete: boolean;
+  started_at: string;
+  last_updated: string;
+}
+
+interface Props {
+  githubUsername: string;
+  apiBase?: string;
+}
+
+export function OnboardingChecklist({ githubUsername, apiBase = "/api/v1" }: Props) {
+  const [progress, setProgress] = useState<OnboardingProgress | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [completing, setCompleting] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetch(`${apiBase}/contributors/onboarding/${githubUsername}`)
+      .then((r) => r.json())
+      .then(setProgress)
+      .catch(() => setError("Failed to load onboarding progress"))
+      .finally(() => setLoading(false));
+  }, [githubUsername, apiBase]);
+
+  async function markComplete(step: string) {
+    setCompleting(step);
+    try {
+      const res = await fetch(
+        `${apiBase}/contributors/onboarding/${githubUsername}/complete`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ step }),
+        }
+      );
+      if (!res.ok) throw new Error("Request failed");
+      setProgress(await res.json());
+    } catch {
+      setError("Failed to update step");
+    } finally {
+      setCompleting(null);
+    }
+  }
+
+  if (loading) return <p className="onboarding-loading">Loading onboarding checklist…</p>;
+  if (error) return <p className="onboarding-error">{error}</p>;
+  if (!progress) return null;
+
+  return (
+    <div className="onboarding-checklist">
+      <h2>Contributor Onboarding</h2>
+      <p className="onboarding-username">@{progress.github_username}</p>
+
+      <div className="onboarding-progress-bar">
+        <div
+          className="onboarding-progress-fill"
+          style={{ width: `${progress.progress_pct}%` }}
+        />
+      </div>
+      <p className="onboarding-progress-label">
+        {progress.completed_count} / {progress.total_steps} steps complete ({progress.progress_pct}%)
+      </p>
+
+      {progress.is_complete && (
+        <p className="onboarding-complete-badge">Onboarding complete!</p>
+      )}
+
+      <ul className="onboarding-steps">
+        {progress.checklist.map((item) => (
+          <li key={item.step} className={`onboarding-step ${item.completed ? "completed" : ""}`}>
+            <span className="onboarding-step-icon">{item.completed ? "✓" : "○"}</span>
+            <span className="onboarding-step-label">{item.label}</span>
+            {!item.completed && (
+              <button
+                className="onboarding-step-btn"
+                disabled={completing === item.step}
+                onClick={() => markComplete(item.step)}
+              >
+                {completing === item.step ? "Saving…" : "Mark done"}
+              </button>
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/web/src/components/OnboardingChecklist/index.ts
+++ b/web/src/components/OnboardingChecklist/index.ts
@@ -1,0 +1,1 @@
+export { OnboardingChecklist } from "./OnboardingChecklist";

--- a/web/src/test/OnboardingChecklist.test.tsx
+++ b/web/src/test/OnboardingChecklist.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import { vi } from 'vitest'
+import { OnboardingChecklist } from '../components/OnboardingChecklist'
+
+const mockProgress = {
+  github_username: 'octocat',
+  checklist: [
+    { step: 'fork_repo', label: 'Fork the repository', completed: true },
+    { step: 'setup_dev_environment', label: 'Set up dev environment', completed: false },
+    { step: 'run_tests', label: 'Run the test suite', completed: false },
+    { step: 'first_pr', label: 'Open your first pull request', completed: false },
+  ],
+  completed_count: 1,
+  total_steps: 4,
+  progress_pct: 25,
+  is_complete: false,
+  started_at: '2026-01-01T00:00:00Z',
+  last_updated: '2026-01-01T00:00:00Z',
+}
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+    ok: true,
+    json: async () => mockProgress,
+  }))
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+test('renders checklist items', async () => {
+  render(<OnboardingChecklist githubUsername="octocat" />)
+  await waitFor(() => expect(screen.getByText('Fork the repository')).toBeInTheDocument())
+  expect(screen.getByText('Set up dev environment')).toBeInTheDocument()
+  expect(screen.getByText('Run the test suite')).toBeInTheDocument()
+  expect(screen.getByText('Open your first pull request')).toBeInTheDocument()
+})
+
+test('shows progress percentage', async () => {
+  render(<OnboardingChecklist githubUsername="octocat" />)
+  await waitFor(() => expect(screen.getByText(/25%/)).toBeInTheDocument())
+})
+
+test('completed step has no mark-done button', async () => {
+  render(<OnboardingChecklist githubUsername="octocat" />)
+  await waitFor(() => screen.getByText('Fork the repository'))
+  const buttons = screen.getAllByRole('button', { name: /mark done/i })
+  expect(buttons).toHaveLength(3)
+})
+
+test('clicking mark done calls complete endpoint', async () => {
+  const afterComplete = { ...mockProgress, completed_count: 2, progress_pct: 50 }
+  const fetchMock = vi.fn()
+    .mockResolvedValueOnce({ ok: true, json: async () => mockProgress })
+    .mockResolvedValueOnce({ ok: true, json: async () => afterComplete })
+  vi.stubGlobal('fetch', fetchMock)
+
+  render(<OnboardingChecklist githubUsername="octocat" />)
+  await waitFor(() => screen.getAllByRole('button', { name: /mark done/i }))
+  fireEvent.click(screen.getAllByRole('button', { name: /mark done/i })[0])
+  await waitFor(() => expect(screen.getByText(/50%/)).toBeInTheDocument())
+})
+
+test('shows complete badge when all steps done', async () => {
+  const completeProgress = {
+    ...mockProgress,
+    checklist: mockProgress.checklist.map((i) => ({ ...i, completed: true })),
+    completed_count: 4,
+    progress_pct: 100,
+    is_complete: true,
+  }
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: async () => completeProgress }))
+  render(<OnboardingChecklist githubUsername="octocat" />)
+  await waitFor(() => expect(screen.getByText(/onboarding complete/i)).toBeInTheDocument())
+})


### PR DESCRIPTION
## Summary

- Adds `OnboardingTracker` in `astroml/contributors/onboarding.py` to persist per-contributor checklist progress (fork repo → setup env → run tests → first PR) in a JSON store
- Exposes four REST endpoints under `GET|POST|DELETE /api/v1/contributors/onboarding/{username}` and `GET /api/v1/contributors/onboarding`
- Adds `OnboardingChecklist` React component with progress bar, step completion buttons, and a completion badge
- Includes API integration tests (`api/tests/test_onboarding.py`) and frontend unit tests (`web/src/test/OnboardingChecklist.test.tsx`)

## Test plan

- [ ] `pytest api/tests/test_onboarding.py -v` — all 6 API tests pass
- [ ] `vitest run web/src/test/OnboardingChecklist.test.tsx` — all 5 component tests pass
- [ ] `GET /api/v1/contributors/onboarding/new_user` returns empty checklist (0% progress)
- [ ] `POST .../complete` with `{"step": "fork_repo"}` marks step done and returns 25%
- [ ] `POST .../complete` with an invalid step returns 422
- [ ] All 4 steps completed sets `is_complete: true` and `progress_pct: 100`

Closes Traqora/astroml#281