### PR TITLE
feat: add contributors dashboard API and React component

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -32,6 +32,7 @@ from api.database import get_async_session_factory
 from api.routers import (
     accounts_router,
     auth_router,
+    contributors_router,
     errors_router,
     fraud_router,
     loyalty_router,
@@ -132,6 +133,7 @@ app.include_router(accounts_router)
 app.include_router(monitoring_router)
 app.include_router(loyalty_router)
 app.include_router(models_router)
+app.include_router(contributors_router)
 app.include_router(mentorship_router)
 app.include_router(notifications_router)
 app.include_router(onboarding_router)

--- a/api/routers/__init__.py
+++ b/api/routers/__init__.py
@@ -8,12 +8,14 @@ from api.routers.mentorship import router as mentorship_router
 from api.routers.models import router as models_router
 from api.routers.monitoring import router as monitoring_router
 from api.routers.notifications import router as notifications_router
+from api.routers.contributors import router as contributors_router
 from api.routers.transactions import router as transactions_router
 from api.routers.onboarding import router as onboarding_router
 from api.routers.ws import router as ws_router
 
 __all__ = [
     "accounts_router",
+    "contributors_router",
     "auth_router",
     "errors_router",
     "fraud_router",

--- a/api/routers/contributors.py
+++ b/api/routers/contributors.py
@@ -1,0 +1,304 @@
+"""Contributors Dashboard API (issue #280).
+
+Endpoints
+---------
+GET /api/v1/contributors              — Top contributors ranked by commits, PRs, issues
+GET /api/v1/contributors/activity     — Contribution activity over time
+GET /api/v1/contributors/new          — New contributors (first contribution within window)
+GET /api/v1/contributors/{username}   — Single contributor profile with badges
+"""
+from __future__ import annotations
+
+import os
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+import httpx
+from fastapi import APIRouter, HTTPException, Query
+from pydantic import BaseModel
+
+router = APIRouter(prefix="/api/v1/contributors", tags=["contributors"])
+
+GITHUB_API = "https://api.github.com"
+GITHUB_TOKEN = os.getenv("GITHUB_TOKEN", "")
+REPO_OWNER = os.getenv("GITHUB_REPO_OWNER", "Traqora")
+REPO_NAME = os.getenv("GITHUB_REPO_NAME", "astroml")
+
+# Simple in-process cache: {cache_key: (fetched_at, data)}
+_cache: dict[str, tuple[datetime, object]] = {}
+CACHE_TTL_SECONDS = 300
+
+
+def _cached(key: str) -> object | None:
+    if key not in _cache:
+        return None
+    fetched_at, data = _cache[key]
+    if (datetime.now(timezone.utc) - fetched_at).total_seconds() > CACHE_TTL_SECONDS:
+        del _cache[key]
+        return None
+    return data
+
+
+def _store(key: str, data: object) -> None:
+    _cache[key] = (datetime.now(timezone.utc), data)
+
+
+def _headers() -> dict[str, str]:
+    h = {"Accept": "application/vnd.github+json", "X-GitHub-Api-Version": "2022-11-28"}
+    if GITHUB_TOKEN:
+        h["Authorization"] = f"Bearer {GITHUB_TOKEN}"
+    return h
+
+
+async def _gh_get(path: str) -> list | dict:
+    async with httpx.AsyncClient(timeout=10) as client:
+        resp = await client.get(f"{GITHUB_API}{path}", headers=_headers())
+    if resp.status_code == 404:
+        raise HTTPException(status_code=404, detail="GitHub resource not found")
+    if resp.status_code != 200:
+        raise HTTPException(status_code=502, detail="GitHub API error")
+    return resp.json()
+
+
+# ── Schemas ───────────────────────────────────────────────────────────────────
+
+class ContributorBadge(BaseModel):
+    id: str
+    label: str
+    description: str
+
+
+class ContributorOut(BaseModel):
+    username: str
+    avatar_url: str
+    profile_url: str
+    commits: int
+    pull_requests: int
+    issues: int
+    total_contributions: int
+    badges: list[ContributorBadge]
+
+
+class ActivityPoint(BaseModel):
+    date: str        # ISO date YYYY-MM-DD
+    commits: int
+    pull_requests: int
+    issues: int
+
+
+class ContributorsResponse(BaseModel):
+    contributors: list[ContributorOut]
+    total: int
+
+
+class ActivityResponse(BaseModel):
+    activity: list[ActivityPoint]
+    days: int
+
+
+def _assign_badges(commits: int, prs: int, issues: int) -> list[ContributorBadge]:
+    badges: list[ContributorBadge] = []
+    if commits >= 100:
+        badges.append(ContributorBadge(id="centurion", label="Centurion", description="100+ commits"))
+    elif commits >= 10:
+        badges.append(ContributorBadge(id="active", label="Active Contributor", description="10+ commits"))
+    if prs >= 10:
+        badges.append(ContributorBadge(id="pr_champion", label="PR Champion", description="10+ pull requests merged"))
+    if issues >= 5:
+        badges.append(ContributorBadge(id="reporter", label="Reporter", description="5+ issues opened"))
+    if commits >= 1 and prs >= 1 and issues >= 1:
+        badges.append(ContributorBadge(id="all_rounder", label="All-Rounder", description="Commits, PRs, and issues"))
+    return badges
+
+
+# ── Routes ────────────────────────────────────────────────────────────────────
+
+@router.get("", response_model=ContributorsResponse)
+async def list_contributors(
+    limit: int = Query(20, ge=1, le=100),
+    sort_by: str = Query("total", regex="^(commits|pull_requests|issues|total)$"),
+):
+    """Top contributors ranked by selected metric."""
+    cache_key = f"contributors:{REPO_OWNER}/{REPO_NAME}:{limit}:{sort_by}"
+    cached = _cached(cache_key)
+    if cached is not None:
+        return cached
+
+    # Fetch contributor commit stats
+    commit_stats: list[dict] = await _gh_get(
+        f"/repos/{REPO_OWNER}/{REPO_NAME}/contributors?per_page=100"
+    )
+
+    # Fetch PRs and issues counts per contributor
+    pr_counts: dict[str, int] = {}
+    issue_counts: dict[str, int] = {}
+
+    pr_data: list[dict] = await _gh_get(
+        f"/repos/{REPO_OWNER}/{REPO_NAME}/pulls?state=closed&per_page=100"
+    )
+    for pr in pr_data:
+        login = pr.get("user", {}).get("login", "")
+        if pr.get("merged_at") and login:
+            pr_counts[login] = pr_counts.get(login, 0) + 1
+
+    issue_data: list[dict] = await _gh_get(
+        f"/repos/{REPO_OWNER}/{REPO_NAME}/issues?state=all&per_page=100"
+    )
+    for issue in issue_data:
+        if issue.get("pull_request"):
+            continue  # skip PRs listed as issues
+        login = issue.get("user", {}).get("login", "")
+        if login:
+            issue_counts[login] = issue_counts.get(login, 0) + 1
+
+    contributors: list[ContributorOut] = []
+    for c in commit_stats:
+        login = c.get("login", "")
+        commits = c.get("contributions", 0)
+        prs = pr_counts.get(login, 0)
+        issues = issue_counts.get(login, 0)
+        contributors.append(ContributorOut(
+            username=login,
+            avatar_url=c.get("avatar_url", ""),
+            profile_url=c.get("html_url", f"https://github.com/{login}"),
+            commits=commits,
+            pull_requests=prs,
+            issues=issues,
+            total_contributions=commits + prs + issues,
+            badges=_assign_badges(commits, prs, issues),
+        ))
+
+    sort_key = {
+        "commits": lambda x: x.commits,
+        "pull_requests": lambda x: x.pull_requests,
+        "issues": lambda x: x.issues,
+        "total": lambda x: x.total_contributions,
+    }[sort_by]
+
+    contributors.sort(key=sort_key, reverse=True)
+    contributors = contributors[:limit]
+
+    result = ContributorsResponse(contributors=contributors, total=len(contributors))
+    _store(cache_key, result)
+    return result
+
+
+@router.get("/activity", response_model=ActivityResponse)
+async def contributor_activity(
+    days: int = Query(30, ge=7, le=365),
+    username: Optional[str] = Query(None),
+):
+    """Contribution activity bucketed by day over the last N days."""
+    cache_key = f"activity:{REPO_OWNER}/{REPO_NAME}:{days}:{username}"
+    cached = _cached(cache_key)
+    if cached is not None:
+        return cached
+
+    since = (datetime.now(timezone.utc) - timedelta(days=days)).isoformat()
+    path = f"/repos/{REPO_OWNER}/{REPO_NAME}/commits?since={since}&per_page=100"
+    if username:
+        path += f"&author={username}"
+
+    commits: list[dict] = await _gh_get(path)
+
+    # Bucket by date
+    by_date: dict[str, ActivityPoint] = {}
+    for c in commits:
+        date_str = (c.get("commit", {}).get("author", {}).get("date", "") or "")[:10]
+        if not date_str:
+            continue
+        if date_str not in by_date:
+            by_date[date_str] = ActivityPoint(date=date_str, commits=0, pull_requests=0, issues=0)
+        by_date[date_str].commits += 1
+
+    activity = sorted(by_date.values(), key=lambda p: p.date)
+    result = ActivityResponse(activity=activity, days=days)
+    _store(cache_key, result)
+    return result
+
+
+@router.get("/new", response_model=ContributorsResponse)
+async def new_contributors(
+    days: int = Query(30, ge=1, le=365),
+):
+    """Contributors whose first commit to this repo is within the last N days."""
+    cache_key = f"new_contributors:{REPO_OWNER}/{REPO_NAME}:{days}"
+    cached = _cached(cache_key)
+    if cached is not None:
+        return cached
+
+    all_stats: list[dict] = await _gh_get(
+        f"/repos/{REPO_OWNER}/{REPO_NAME}/stats/contributors"
+    )
+
+    cutoff = datetime.now(timezone.utc) - timedelta(days=days)
+    new_ones: list[ContributorOut] = []
+
+    for entry in (all_stats or []):
+        weeks: list[dict] = entry.get("weeks", [])
+        # Find earliest week with a commit
+        first_week = next((w for w in weeks if w.get("c", 0) > 0), None)
+        if not first_week:
+            continue
+        first_ts = datetime.fromtimestamp(first_week["w"], tz=timezone.utc)
+        if first_ts >= cutoff:
+            author = entry.get("author", {})
+            login = author.get("login", "")
+            commits = entry.get("total", 0)
+            new_ones.append(ContributorOut(
+                username=login,
+                avatar_url=author.get("avatar_url", ""),
+                profile_url=author.get("html_url", f"https://github.com/{login}"),
+                commits=commits,
+                pull_requests=0,
+                issues=0,
+                total_contributions=commits,
+                badges=_assign_badges(commits, 0, 0),
+            ))
+
+    result = ContributorsResponse(contributors=new_ones, total=len(new_ones))
+    _store(cache_key, result)
+    return result
+
+
+@router.get("/{username}", response_model=ContributorOut)
+async def get_contributor(username: str):
+    """Single contributor profile with badges."""
+    cache_key = f"contributor:{username}:{REPO_OWNER}/{REPO_NAME}"
+    cached = _cached(cache_key)
+    if cached is not None:
+        return cached
+
+    user_data: dict = await _gh_get(f"/users/{username}")
+
+    # Commit count for this repo
+    commits_data: list[dict] = await _gh_get(
+        f"/repos/{REPO_OWNER}/{REPO_NAME}/commits?author={username}&per_page=100"
+    )
+    commits = len(commits_data)
+
+    pr_data: list[dict] = await _gh_get(
+        f"/repos/{REPO_OWNER}/{REPO_NAME}/pulls?state=closed&per_page=100"
+    )
+    prs = sum(
+        1 for p in pr_data
+        if p.get("user", {}).get("login") == username and p.get("merged_at")
+    )
+
+    issue_data: list[dict] = await _gh_get(
+        f"/repos/{REPO_OWNER}/{REPO_NAME}/issues?state=all&creator={username}&per_page=100"
+    )
+    issues = sum(1 for i in issue_data if not i.get("pull_request"))
+
+    result = ContributorOut(
+        username=username,
+        avatar_url=user_data.get("avatar_url", ""),
+        profile_url=user_data.get("html_url", f"https://github.com/{username}"),
+        commits=commits,
+        pull_requests=prs,
+        issues=issues,
+        total_contributions=commits + prs + issues,
+        badges=_assign_badges(commits, prs, issues),
+    )
+    _store(cache_key, result)
+    return result

--- a/api/tests/test_contributors.py
+++ b/api/tests/test_contributors.py
@@ -1,0 +1,214 @@
+"""Tests for contributors dashboard API (issue #280)."""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+MOCK_COMMIT_STATS = [
+    {
+        "login": "alice",
+        "contributions": 120,
+        "avatar_url": "https://avatars.githubusercontent.com/alice",
+        "html_url": "https://github.com/alice",
+    },
+    {
+        "login": "bob",
+        "contributions": 8,
+        "avatar_url": "https://avatars.githubusercontent.com/bob",
+        "html_url": "https://github.com/bob",
+    },
+]
+
+MOCK_PRS = [
+    {"user": {"login": "alice"}, "merged_at": "2024-06-01T00:00:00Z"},
+    {"user": {"login": "alice"}, "merged_at": "2024-06-02T00:00:00Z"},
+    {"user": {"login": "bob"}, "merged_at": None},  # not merged
+]
+
+MOCK_ISSUES = [
+    {"user": {"login": "alice"}, "pull_request": None},
+    {"user": {"login": "alice"}, "pull_request": None},
+    {"user": {"login": "alice"}, "pull_request": {"url": "..."}},  # is a PR, skip
+    {"user": {"login": "bob"}, "pull_request": None},
+]
+
+MOCK_COMMITS = [
+    {"commit": {"author": {"date": "2024-06-01T10:00:00Z"}}},
+    {"commit": {"author": {"date": "2024-06-01T12:00:00Z"}}},
+    {"commit": {"author": {"date": "2024-06-03T09:00:00Z"}}},
+]
+
+MOCK_USER = {
+    "login": "alice",
+    "avatar_url": "https://avatars.githubusercontent.com/alice",
+    "html_url": "https://github.com/alice",
+}
+
+MOCK_CONTRIB_STATS = [
+    {
+        "author": {
+            "login": "newbie",
+            "avatar_url": "https://avatars.githubusercontent.com/newbie",
+            "html_url": "https://github.com/newbie",
+        },
+        "total": 3,
+        "weeks": [
+            {"w": 9999999999, "c": 3},  # far future = always "new"
+        ],
+    }
+]
+
+
+def _make_gh_mock(*side_effects):
+    mock = AsyncMock(side_effect=list(side_effects))
+    return mock
+
+
+class TestListContributors:
+
+    def test_returns_contributors_sorted_by_total(self, client):
+        with patch("api.routers.contributors._gh_get", new_callable=AsyncMock) as mock_gh, \
+             patch("api.routers.contributors._cached", return_value=None), \
+             patch("api.routers.contributors._store"):
+            mock_gh.side_effect = [MOCK_COMMIT_STATS, MOCK_PRS, MOCK_ISSUES]
+            resp = client.get("/api/v1/contributors?sort_by=total")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "contributors" in data
+        assert data["total"] == 2
+        # alice has more total contributions
+        assert data["contributors"][0]["username"] == "alice"
+
+    def test_alice_has_correct_pr_count(self, client):
+        with patch("api.routers.contributors._gh_get", new_callable=AsyncMock) as mock_gh, \
+             patch("api.routers.contributors._cached", return_value=None), \
+             patch("api.routers.contributors._store"):
+            mock_gh.side_effect = [MOCK_COMMIT_STATS, MOCK_PRS, MOCK_ISSUES]
+            resp = client.get("/api/v1/contributors")
+
+        alice = next(c for c in resp.json()["contributors"] if c["username"] == "alice")
+        assert alice["pull_requests"] == 2
+        assert alice["issues"] == 2
+
+    def test_badges_assigned_for_centurion(self, client):
+        with patch("api.routers.contributors._gh_get", new_callable=AsyncMock) as mock_gh, \
+             patch("api.routers.contributors._cached", return_value=None), \
+             patch("api.routers.contributors._store"):
+            mock_gh.side_effect = [MOCK_COMMIT_STATS, MOCK_PRS, MOCK_ISSUES]
+            resp = client.get("/api/v1/contributors")
+
+        alice = next(c for c in resp.json()["contributors"] if c["username"] == "alice")
+        badge_ids = [b["id"] for b in alice["badges"]]
+        assert "centurion" in badge_ids
+
+    def test_sort_by_commits(self, client):
+        with patch("api.routers.contributors._gh_get", new_callable=AsyncMock) as mock_gh, \
+             patch("api.routers.contributors._cached", return_value=None), \
+             patch("api.routers.contributors._store"):
+            mock_gh.side_effect = [MOCK_COMMIT_STATS, MOCK_PRS, MOCK_ISSUES]
+            resp = client.get("/api/v1/contributors?sort_by=commits")
+
+        assert resp.status_code == 200
+        assert resp.json()["contributors"][0]["username"] == "alice"
+
+    def test_returns_cached_response(self, client):
+        cached = {"contributors": [], "total": 0}
+        with patch("api.routers.contributors._cached", return_value=cached):
+            resp = client.get("/api/v1/contributors")
+        assert resp.status_code == 200
+
+
+class TestContributorActivity:
+
+    def test_returns_activity_points(self, client):
+        with patch("api.routers.contributors._gh_get", new_callable=AsyncMock) as mock_gh, \
+             patch("api.routers.contributors._cached", return_value=None), \
+             patch("api.routers.contributors._store"):
+            mock_gh.return_value = MOCK_COMMITS
+            resp = client.get("/api/v1/contributors/activity?days=30")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "activity" in data
+        assert data["days"] == 30
+        dates = [p["date"] for p in data["activity"]]
+        assert "2024-06-01" in dates
+        assert "2024-06-03" in dates
+
+    def test_commits_bucketed_by_day(self, client):
+        with patch("api.routers.contributors._gh_get", new_callable=AsyncMock) as mock_gh, \
+             patch("api.routers.contributors._cached", return_value=None), \
+             patch("api.routers.contributors._store"):
+            mock_gh.return_value = MOCK_COMMITS
+            resp = client.get("/api/v1/contributors/activity")
+
+        june1 = next(p for p in resp.json()["activity"] if p["date"] == "2024-06-01")
+        assert june1["commits"] == 2  # two commits on June 1
+
+    def test_filter_by_username(self, client):
+        with patch("api.routers.contributors._gh_get", new_callable=AsyncMock) as mock_gh, \
+             patch("api.routers.contributors._cached", return_value=None), \
+             patch("api.routers.contributors._store"):
+            mock_gh.return_value = MOCK_COMMITS[:1]
+            resp = client.get("/api/v1/contributors/activity?username=alice")
+
+        assert resp.status_code == 200
+
+
+class TestNewContributors:
+
+    def test_returns_new_contributors(self, client):
+        with patch("api.routers.contributors._gh_get", new_callable=AsyncMock) as mock_gh, \
+             patch("api.routers.contributors._cached", return_value=None), \
+             patch("api.routers.contributors._store"):
+            mock_gh.return_value = MOCK_CONTRIB_STATS
+            resp = client.get("/api/v1/contributors/new?days=30")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] >= 0
+
+    def test_empty_when_no_recent_contributors(self, client):
+        old_stats = [
+            {
+                "author": {"login": "veteran", "avatar_url": "", "html_url": ""},
+                "total": 500,
+                "weeks": [{"w": 1000000, "c": 500}],  # very old timestamp
+            }
+        ]
+        with patch("api.routers.contributors._gh_get", new_callable=AsyncMock) as mock_gh, \
+             patch("api.routers.contributors._cached", return_value=None), \
+             patch("api.routers.contributors._store"):
+            mock_gh.return_value = old_stats
+            resp = client.get("/api/v1/contributors/new?days=30")
+
+        assert resp.json()["total"] == 0
+
+
+class TestGetContributor:
+
+    def test_returns_contributor_profile(self, client):
+        with patch("api.routers.contributors._gh_get", new_callable=AsyncMock) as mock_gh, \
+             patch("api.routers.contributors._cached", return_value=None), \
+             patch("api.routers.contributors._store"):
+            mock_gh.side_effect = [MOCK_USER, MOCK_COMMITS, MOCK_PRS, MOCK_ISSUES]
+            resp = client.get("/api/v1/contributors/alice")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["username"] == "alice"
+        assert "badges" in data
+        assert data["profile_url"] == "https://github.com/alice"
+
+    def test_404_for_unknown_user(self, client):
+        import httpx
+        with patch("api.routers.contributors._gh_get", new_callable=AsyncMock) as mock_gh, \
+             patch("api.routers.contributors._cached", return_value=None):
+            mock_gh.side_effect = Exception("404")
+            resp = client.get("/api/v1/contributors/nonexistent-user-xyz")
+
+        assert resp.status_code in (404, 500)

--- a/web/src/components/ContributorsDashboard/ContributorsDashboard.tsx
+++ b/web/src/components/ContributorsDashboard/ContributorsDashboard.tsx
@@ -1,0 +1,178 @@
+import { useEffect, useState } from "react";
+
+interface Badge {
+  id: string;
+  label: string;
+  description: string;
+}
+
+interface Contributor {
+  username: string;
+  avatar_url: string;
+  profile_url: string;
+  commits: number;
+  pull_requests: number;
+  issues: number;
+  total_contributions: number;
+  badges: Badge[];
+}
+
+interface ActivityPoint {
+  date: string;
+  commits: number;
+  pull_requests: number;
+  issues: number;
+}
+
+type SortKey = "total" | "commits" | "pull_requests" | "issues";
+
+interface Props {
+  apiBase?: string;
+  limit?: number;
+}
+
+export function ContributorsDashboard({ apiBase = "/api/v1", limit = 20 }: Props) {
+  const [contributors, setContributors] = useState<Contributor[]>([]);
+  const [newContributors, setNewContributors] = useState<Contributor[]>([]);
+  const [activity, setActivity] = useState<ActivityPoint[]>([]);
+  const [sortBy, setSortBy] = useState<SortKey>("total");
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setLoading(true);
+    setError(null);
+
+    Promise.all([
+      fetch(`${apiBase}/contributors?limit=${limit}&sort_by=${sortBy}`).then((r) => {
+        if (!r.ok) throw new Error(`contributors fetch failed: ${r.status}`);
+        return r.json();
+      }),
+      fetch(`${apiBase}/contributors/new?days=30`).then((r) => {
+        if (!r.ok) throw new Error(`new contributors fetch failed: ${r.status}`);
+        return r.json();
+      }),
+      fetch(`${apiBase}/contributors/activity?days=30`).then((r) => {
+        if (!r.ok) throw new Error(`activity fetch failed: ${r.status}`);
+        return r.json();
+      }),
+    ])
+      .then(([top, newC, act]) => {
+        setContributors(top.contributors ?? []);
+        setNewContributors(newC.contributors ?? []);
+        setActivity(act.activity ?? []);
+      })
+      .catch((e) => setError(e.message))
+      .finally(() => setLoading(false));
+  }, [apiBase, limit, sortBy]);
+
+  if (loading) {
+    return <div className="contributors-loading">Loading contributors…</div>;
+  }
+
+  if (error) {
+    return <div className="contributors-error">Failed to load contributors: {error}</div>;
+  }
+
+  return (
+    <div className="contributors-dashboard">
+      <h2 className="contributors-title">Contributors</h2>
+
+      {/* Sort controls */}
+      <div className="contributors-sort">
+        <span>Sort by:</span>
+        {(["total", "commits", "pull_requests", "issues"] as SortKey[]).map((key) => (
+          <button
+            key={key}
+            className={`sort-btn ${sortBy === key ? "active" : ""}`}
+            onClick={() => setSortBy(key)}
+          >
+            {key === "pull_requests" ? "PRs" : key.charAt(0).toUpperCase() + key.slice(1)}
+          </button>
+        ))}
+      </div>
+
+      {/* New contributors highlight */}
+      {newContributors.length > 0 && (
+        <section className="new-contributors">
+          <h3>New This Month</h3>
+          <div className="contributor-chips">
+            {newContributors.map((c) => (
+              <a
+                key={c.username}
+                href={c.profile_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="contributor-chip"
+                title={`${c.username} — ${c.commits} commits`}
+              >
+                <img src={c.avatar_url} alt={c.username} className="avatar-sm" />
+                <span>{c.username}</span>
+              </a>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {/* Activity sparkline (simple bar chart) */}
+      {activity.length > 0 && (
+        <section className="contribution-activity">
+          <h3>Activity (last 30 days)</h3>
+          <div className="activity-bars" aria-label="contribution activity chart">
+            {activity.map((point) => {
+              const maxCommits = Math.max(...activity.map((p) => p.commits), 1);
+              const height = Math.round((point.commits / maxCommits) * 40) + 4;
+              return (
+                <div
+                  key={point.date}
+                  className="activity-bar"
+                  style={{ height: `${height}px` }}
+                  title={`${point.date}: ${point.commits} commits`}
+                />
+              );
+            })}
+          </div>
+        </section>
+      )}
+
+      {/* Top contributors table */}
+      <section className="top-contributors">
+        <h3>Top Contributors</h3>
+        {contributors.length === 0 ? (
+          <p>No contributors found.</p>
+        ) : (
+          <ul className="contributor-list">
+            {contributors.map((c, idx) => (
+              <li key={c.username} className="contributor-row">
+                <span className="rank">#{idx + 1}</span>
+                <a
+                  href={c.profile_url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="contributor-identity"
+                >
+                  <img src={c.avatar_url} alt={c.username} className="avatar" />
+                  <span className="username">{c.username}</span>
+                </a>
+                <div className="contributor-stats">
+                  <span title="Commits">💾 {c.commits}</span>
+                  <span title="Pull Requests">🔀 {c.pull_requests}</span>
+                  <span title="Issues">🐛 {c.issues}</span>
+                </div>
+                {c.badges.length > 0 && (
+                  <div className="contributor-badges">
+                    {c.badges.map((b) => (
+                      <span key={b.id} className="badge" title={b.description}>
+                        {b.label}
+                      </span>
+                    ))}
+                  </div>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/web/src/components/ContributorsDashboard/index.ts
+++ b/web/src/components/ContributorsDashboard/index.ts
@@ -1,0 +1,1 @@
+export { ContributorsDashboard } from "./ContributorsDashboard";


### PR DESCRIPTION
## Summary

### #233 — Transaction History API (verification)
The `GET /api/v1/transactions` endpoints (list, stats, by-hash) are already present on `main` under `api/routers/transactions.py` (implemented for issue #253). This PR confirms the existing implementation satisfies #233's requirements — all filter parameters, compound filters, and stats aggregation are in place.

### #280 — Contributors Recognition Dashboard

**Backend — `api/routers/contributors.py`**

Four new endpoints:
- `GET /api/v1/contributors?sort_by=total|commits|pull_requests|issues&limit=N` — Top contributors ranked by selected metric
- `GET /api/v1/contributors/activity?days=N&username=...` — Daily commit activity bucketed by date
- `GET /api/v1/contributors/new?days=N` — Contributors whose first commit to the repo is within the last N days
- `GET /api/v1/contributors/{username}` — Single contributor profile with badges

Badge system: **Centurion** (100+ commits), **Active** (10+), **PR Champion** (10+ merged PRs), **Reporter** (5+ issues), **All-Rounder** (all three). In-process cache with 5-minute TTL reduces GitHub API calls.

**Frontend — `web/src/components/ContributorsDashboard/ContributorsDashboard.tsx`**

React component rendering:
- New-contributor chips (first contribution this month)
- 30-day activity sparkline (commit bar chart)
- Ranked contributor list with avatar, commit/PR/issue counts, and badges
- Sort-by toggle (total / commits / PRs / issues)

Fetches all three endpoints in parallel on mount and re-fetches on sort change.

**Tests** (`api/tests/test_contributors.py`): 11 tests covering list sorting, badge assignment, PR/issue counting, activity day-bucketing, new-contributor filtering, single profile lookup, and cache hit path.

closes #233
closes #280