### PR TITLE
feat(contact): contact form with email integration & support tickets

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -38,6 +38,7 @@ from api.routers import (
     auth_router,
     backup_router,
     chat_router,
+    contact_router,
     contributors_router,
     errors_router,
     faq_router,
@@ -143,6 +144,7 @@ app.include_router(auth_router)
 app.include_router(audit_router)
 app.include_router(rate_limit_router)
 app.include_router(errors_router)
+app.include_router(contact_router)
 app.include_router(transactions_router)
 app.include_router(fraud_router)
 app.include_router(accounts_router)

--- a/api/config.py
+++ b/api/config.py
@@ -39,5 +39,14 @@ class Settings(BaseSettings):
     zipkin_endpoint: str = "http://localhost:9411/api/v2/spans"
     service_name: str = "astroml-api"
 
+    # Contact form / support tickets (issue #305)
+    # Empty reCAPTCHA secret disables spam verification (dev/test default).
+    contact_recaptcha_secret: str = ""
+    contact_recaptcha_min_score: float = 0.5  # reCAPTCHA v3 score threshold
+    # Empty SendGrid key → emails are logged instead of sent (dev/test default).
+    sendgrid_api_key: str = ""
+    contact_email_from: str = "no-reply@astroml.dev"
+    contact_support_email: str = "support@astroml.dev"
+
 
 settings = Settings()

--- a/api/models/orm.py
+++ b/api/models/orm.py
@@ -536,5 +536,26 @@ class AuditLog(Base):
     )
 
 
+class SupportTicket(Base):
+    """Support ticket generated from a contact-form submission (issue #305)."""
+
+    __tablename__ = "support_tickets"
+
+    id: Mapped[int] = mapped_column(_ID, primary_key=True, autoincrement=True)
+    reference: Mapped[str] = mapped_column(String(20), nullable=False, unique=True)
+    name: Mapped[str] = mapped_column(String(120), nullable=False)
+    email: Mapped[str] = mapped_column(String(254), nullable=False)
+    subject: Mapped[str] = mapped_column(String(200), nullable=False)
+    message: Mapped[str] = mapped_column(Text, nullable=False)
+    status: Mapped[str] = mapped_column(String(20), nullable=False, server_default="open")
+    created_at: Mapped[datetime] = mapped_column(nullable=False, server_default=func.now())
+
+    __table_args__ = (
+        Index("ix_support_tickets_reference", "reference"),
+        Index("ix_support_tickets_email", "email"),
+        Index("ix_support_tickets_status", "status"),
+    )
+
+
 # Backward-compatible aliases removed — use ApiAccount / ApiTransaction to avoid
 # SQLAlchemy mapper name collisions with astroml.db.schema.

--- a/api/routers/__init__.py
+++ b/api/routers/__init__.py
@@ -4,6 +4,7 @@ from api.routers.audit import router as audit_router
 from api.routers.auth import router as auth_router
 from api.routers.backup import router as backup_router
 from api.routers.chat import router as chat_router
+from api.routers.contact import router as contact_router
 from api.routers.errors import router as errors_router
 from api.routers.faq import router as faq_router
 from api.routers.fraud import router as fraud_router
@@ -24,6 +25,7 @@ __all__ = [
     "audit_router",
     "backup_router",
     "chat_router",
+    "contact_router",
     "contributors_router",
     "auth_router",
     "errors_router",

--- a/api/routers/contact.py
+++ b/api/routers/contact.py
@@ -1,0 +1,74 @@
+"""Contact form & support ticket router (issue #305).
+
+Accepts contact form submissions, verifies reCAPTCHA (when configured),
+persists a support ticket, and sends a support notification plus an auto-reply
+confirmation to the submitter.
+"""
+from __future__ import annotations
+
+import secrets
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api.database import get_db
+from api.models.orm import SupportTicket
+from api.schemas import ContactFormIn, ContactSubmitResponse, SupportTicketOut
+from api.services.email import send_contact_emails
+from api.services.recaptcha import verify_recaptcha
+
+router = APIRouter(prefix="/api/v1/contact", tags=["contact"])
+
+
+def _generate_reference() -> str:
+    """Short, human-quotable ticket reference, e.g. ``TKT-1A2B3C4D``."""
+    return "TKT-" + secrets.token_hex(4).upper()
+
+
+@router.post("", response_model=ContactSubmitResponse, status_code=201)
+async def submit_contact_form(
+    payload: ContactFormIn,
+    db: AsyncSession = Depends(get_db),
+) -> ContactSubmitResponse:
+    """Validate, spam-check, persist a support ticket, and send emails."""
+    if not await verify_recaptcha(payload.recaptcha_token):
+        raise HTTPException(status_code=400, detail="reCAPTCHA verification failed")
+
+    ticket = SupportTicket(
+        reference=_generate_reference(),
+        name=payload.name,
+        email=payload.email,
+        subject=payload.subject,
+        message=payload.message,
+        status="open",
+    )
+    db.add(ticket)
+    await db.commit()
+    await db.refresh(ticket)
+
+    # Email is best-effort — a delivery failure must not fail the submission.
+    try:
+        await send_contact_emails(ticket)
+    except Exception:  # pragma: no cover - defensive
+        pass
+
+    return ContactSubmitResponse(
+        message="Your message has been received. We'll be in touch shortly.",
+        ticket=SupportTicketOut.model_validate(ticket),
+    )
+
+
+@router.get("/tickets/{reference}", response_model=SupportTicketOut)
+async def get_ticket(
+    reference: str,
+    db: AsyncSession = Depends(get_db),
+) -> SupportTicket:
+    """Look up a support ticket by its reference."""
+    result = await db.execute(
+        select(SupportTicket).where(SupportTicket.reference == reference)
+    )
+    ticket = result.scalar_one_or_none()
+    if ticket is None:
+        raise HTTPException(status_code=404, detail="Ticket not found")
+    return ticket

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -1,10 +1,11 @@
 """Pydantic schemas shared across all API routers."""
 from __future__ import annotations
 
+import re
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 
 # ─── Fraud ────────────────────────────────────────────────────────────────────
@@ -539,3 +540,46 @@ class FAQSuggestionListResponse(BaseModel):
     page: int
     page_size: int
     total: int
+
+
+# ─── Contact / Support tickets (issue #305) ─────────────────────────────────
+
+_EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+
+
+class ContactFormIn(BaseModel):
+    name: str = Field(min_length=1, max_length=120)
+    email: str = Field(min_length=3, max_length=254)
+    subject: str = Field(min_length=1, max_length=200)
+    message: str = Field(min_length=1, max_length=5000)
+    # reCAPTCHA token from the frontend widget; optional when verification is off.
+    recaptcha_token: Optional[str] = None
+
+    @field_validator("name", "subject", "message")
+    @classmethod
+    def _not_blank(cls, v: str) -> str:
+        if not v or not v.strip():
+            raise ValueError("must not be blank")
+        return v.strip()
+
+    @field_validator("email")
+    @classmethod
+    def _valid_email(cls, v: str) -> str:
+        v = v.strip()
+        if not _EMAIL_RE.match(v):
+            raise ValueError("invalid email address")
+        return v
+
+
+class SupportTicketOut(BaseModel):
+    reference: str
+    status: str
+    created_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
+class ContactSubmitResponse(BaseModel):
+    message: str
+    ticket: SupportTicketOut

--- a/api/services/email.py
+++ b/api/services/email.py
@@ -1,0 +1,71 @@
+"""Transactional email for the contact form (issue #305).
+
+Sends via SendGrid when ``sendgrid_api_key`` is configured; otherwise logs the
+message so the feature works in development/test without external credentials.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+
+from api.config import settings
+
+logger = logging.getLogger(__name__)
+
+SENDGRID_URL = "https://api.sendgrid.com/v3/mail/send"
+
+
+async def send_email(to: str, subject: str, body: str) -> bool:
+    """Send a plain-text email. Returns True if dispatched to the provider."""
+    api_key = settings.sendgrid_api_key
+    if not api_key:
+        logger.info(
+            "Email not sent (SendGrid not configured) to=%s subject=%s", to, subject
+        )
+        return False
+
+    payload: dict[str, Any] = {
+        "personalizations": [{"to": [{"email": to}]}],
+        "from": {"email": settings.contact_email_from},
+        "subject": subject,
+        "content": [{"type": "text/plain", "value": body}],
+    }
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.post(
+                SENDGRID_URL,
+                json=payload,
+                headers={"Authorization": f"Bearer {api_key}"},
+            )
+        resp.raise_for_status()
+        return True
+    except Exception as exc:  # delivery failure must not break the request
+        logger.warning("Failed to send email to %s: %s", to, exc)
+        return False
+
+
+async def send_contact_emails(ticket: Any) -> None:
+    """Best-effort: notify support and auto-reply to the submitter."""
+    await send_email(
+        to=settings.contact_support_email,
+        subject=f"[{ticket.reference}] New contact: {ticket.subject}",
+        body=(
+            f"New contact form submission ({ticket.reference})\n\n"
+            f"From: {ticket.name} <{ticket.email}>\n"
+            f"Subject: {ticket.subject}\n\n"
+            f"{ticket.message}\n"
+        ),
+    )
+    await send_email(
+        to=ticket.email,
+        subject=f"We received your message ({ticket.reference})",
+        body=(
+            f"Hi {ticket.name},\n\n"
+            f"Thanks for reaching out. Your support ticket {ticket.reference} has "
+            f"been created and our team will get back to you shortly.\n\n"
+            f"Subject: {ticket.subject}\n\n"
+            f"— The AstroML team\n"
+        ),
+    )

--- a/api/services/recaptcha.py
+++ b/api/services/recaptcha.py
@@ -1,0 +1,46 @@
+"""reCAPTCHA verification for the contact form (issue #305).
+
+Verification is skipped when no secret is configured, so the contact form works
+in development/test without a reCAPTCHA key and only enforces spam protection in
+environments where ``contact_recaptcha_secret`` is set.
+"""
+from __future__ import annotations
+
+import logging
+
+import httpx
+
+from api.config import settings
+
+logger = logging.getLogger(__name__)
+
+VERIFY_URL = "https://www.google.com/recaptcha/api/siteverify"
+
+
+async def verify_recaptcha(token: str | None) -> bool:
+    """Return True when the token is valid, or when verification is disabled."""
+    secret = settings.contact_recaptcha_secret
+    if not secret:
+        return True  # verification disabled
+    if not token:
+        return False
+
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.post(
+                VERIFY_URL, data={"secret": secret, "response": token}
+            )
+        data = resp.json()
+    except Exception as exc:  # network/transport error — fail closed
+        logger.warning("reCAPTCHA verification request failed: %s", exc)
+        return False
+
+    if not data.get("success", False):
+        return False
+
+    # reCAPTCHA v3 returns a score in [0, 1]; enforce a minimum when present.
+    score = data.get("score")
+    if score is not None and score < settings.contact_recaptcha_min_score:
+        return False
+
+    return True

--- a/api/tests/test_contact.py
+++ b/api/tests/test_contact.py
@@ -1,0 +1,67 @@
+"""Tests for the contact form & support ticket endpoints — issue #305."""
+from __future__ import annotations
+
+import pytest
+
+VALID = {
+    "name": "Ada Lovelace",
+    "email": "ada@example.com",
+    "subject": "Need help with the API",
+    "message": "I have a question about anomaly scoring.",
+}
+
+
+@pytest.mark.xdist_group("api_contact")
+class TestContactForm:
+    def test_submit_creates_support_ticket(self, client):
+        resp = client.post("/api/v1/contact", json=VALID)
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["ticket"]["reference"].startswith("TKT-")
+        assert data["ticket"]["status"] == "open"
+        assert "received" in data["message"].lower()
+
+    def test_submit_invalid_email_returns_422(self, client):
+        resp = client.post("/api/v1/contact", json={**VALID, "email": "not-an-email"})
+        assert resp.status_code == 422
+
+    def test_submit_blank_message_returns_422(self, client):
+        resp = client.post("/api/v1/contact", json={**VALID, "message": "   "})
+        assert resp.status_code == 422
+
+    def test_submit_missing_field_returns_422(self, client):
+        payload = {k: v for k, v in VALID.items() if k != "subject"}
+        assert client.post("/api/v1/contact", json=payload).status_code == 422
+
+    def test_get_ticket_by_reference(self, client):
+        ref = client.post("/api/v1/contact", json=VALID).json()["ticket"]["reference"]
+        resp = client.get(f"/api/v1/contact/tickets/{ref}")
+        assert resp.status_code == 200
+        assert resp.json()["reference"] == ref
+
+    def test_get_unknown_ticket_returns_404(self, client):
+        assert client.get("/api/v1/contact/tickets/TKT-DOESNOTEXIST").status_code == 404
+
+    def test_recaptcha_failure_returns_400(self, client, monkeypatch):
+        # Force verification to fail regardless of config.
+        from api.routers import contact as contact_module
+
+        async def _reject(_token):
+            return False
+
+        monkeypatch.setattr(contact_module, "verify_recaptcha", _reject)
+        assert client.post("/api/v1/contact", json=VALID).status_code == 400
+
+    def test_emails_sent_on_success(self, client, monkeypatch):
+        # Capture the best-effort email dispatch without hitting the network.
+        from api.routers import contact as contact_module
+
+        sent = {}
+
+        async def _capture(ticket):
+            sent["reference"] = ticket.reference
+
+        monkeypatch.setattr(contact_module, "send_contact_emails", _capture)
+        resp = client.post("/api/v1/contact", json=VALID)
+        assert resp.status_code == 201
+        assert sent.get("reference") == resp.json()["ticket"]["reference"]

--- a/web/src/components/ContactForm.tsx
+++ b/web/src/components/ContactForm.tsx
@@ -1,0 +1,197 @@
+/**
+ * ContactForm (issue #305)
+ *
+ * Lets users reach out for support. Validates input client-side, submits to the
+ * contact API, and on success shows the generated support-ticket reference.
+ *
+ * reCAPTCHA is optional: when `VITE_RECAPTCHA_SITE_KEY` is configured and the
+ * grecaptcha script is loaded, a token is attached to the submission. The
+ * backend skips verification when no secret is configured, so the form works in
+ * development without a key.
+ */
+import React, { useState } from 'react'
+import { post, ApiError } from '../api/client'
+
+interface ContactFormState {
+  name: string
+  email: string
+  subject: string
+  message: string
+}
+
+interface SupportTicket {
+  reference: string
+  status: string
+  created_at: string
+}
+
+interface ContactSubmitResponse {
+  message: string
+  ticket: SupportTicket
+}
+
+const EMAIL_RE = /^[^@\s]+@[^@\s]+\.[^@\s]+$/
+
+const EMPTY: ContactFormState = { name: '', email: '', subject: '', message: '' }
+
+function validate(form: ContactFormState): Partial<Record<keyof ContactFormState, string>> {
+  const errors: Partial<Record<keyof ContactFormState, string>> = {}
+  if (!form.name.trim()) errors.name = 'Name is required'
+  if (!form.email.trim()) errors.email = 'Email is required'
+  else if (!EMAIL_RE.test(form.email.trim())) errors.email = 'Enter a valid email address'
+  if (!form.subject.trim()) errors.subject = 'Subject is required'
+  if (!form.message.trim()) errors.message = 'Message is required'
+  return errors
+}
+
+/** Reads a reCAPTCHA token if the widget is configured and loaded. */
+function getRecaptchaToken(): string | undefined {
+  const grecaptcha = (window as unknown as { grecaptcha?: { getResponse?: () => string } })
+    .grecaptcha
+  const token = grecaptcha?.getResponse?.()
+  return token || undefined
+}
+
+export function ContactForm() {
+  const [form, setForm] = useState<ContactFormState>(EMPTY)
+  const [errors, setErrors] = useState<Partial<Record<keyof ContactFormState, string>>>({})
+  const [status, setStatus] = useState<'idle' | 'submitting' | 'success' | 'error'>('idle')
+  const [serverError, setServerError] = useState('')
+  const [ticketRef, setTicketRef] = useState('')
+
+  const recaptchaSiteKey = import.meta.env.VITE_RECAPTCHA_SITE_KEY as string | undefined
+
+  function update(field: keyof ContactFormState, value: string) {
+    setForm((prev) => ({ ...prev, [field]: value }))
+    setErrors((prev) => ({ ...prev, [field]: undefined }))
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setServerError('')
+    const validationErrors = validate(form)
+    if (Object.keys(validationErrors).length > 0) {
+      setErrors(validationErrors)
+      return
+    }
+
+    setStatus('submitting')
+    try {
+      const res = await post<ContactSubmitResponse>('/api/v1/contact', {
+        name: form.name.trim(),
+        email: form.email.trim(),
+        subject: form.subject.trim(),
+        message: form.message.trim(),
+        recaptcha_token: getRecaptchaToken(),
+      })
+      setTicketRef(res.ticket.reference)
+      setStatus('success')
+      setForm(EMPTY)
+    } catch (err) {
+      setStatus('error')
+      setServerError(
+        err instanceof ApiError
+          ? err.message
+          : 'Something went wrong. Please try again.',
+      )
+    }
+  }
+
+  if (status === 'success') {
+    return (
+      <div className="contact-form contact-form--success" role="status">
+        <h3>Thanks for reaching out!</h3>
+        <p>
+          Your message has been received. Your support ticket reference is{' '}
+          <strong data-testid="ticket-reference">{ticketRef}</strong>. We&apos;ve sent a
+          confirmation to your email and our team will reply soon.
+        </p>
+        <button
+          type="button"
+          onClick={() => {
+            setStatus('idle')
+            setTicketRef('')
+          }}
+        >
+          Send another message
+        </button>
+      </div>
+    )
+  }
+
+  const submitting = status === 'submitting'
+
+  return (
+    <form className="contact-form" onSubmit={handleSubmit} noValidate aria-label="Contact form">
+      <h2>Contact us</h2>
+
+      <div className="contact-form__field">
+        <label htmlFor="contact-name">Name</label>
+        <input
+          id="contact-name"
+          value={form.name}
+          onChange={(e) => update('name', e.target.value)}
+          aria-invalid={errors.name ? 'true' : undefined}
+          disabled={submitting}
+        />
+        {errors.name && <p className="contact-form__error" role="alert">{errors.name}</p>}
+      </div>
+
+      <div className="contact-form__field">
+        <label htmlFor="contact-email">Email</label>
+        <input
+          id="contact-email"
+          type="email"
+          value={form.email}
+          onChange={(e) => update('email', e.target.value)}
+          aria-invalid={errors.email ? 'true' : undefined}
+          disabled={submitting}
+        />
+        {errors.email && <p className="contact-form__error" role="alert">{errors.email}</p>}
+      </div>
+
+      <div className="contact-form__field">
+        <label htmlFor="contact-subject">Subject</label>
+        <input
+          id="contact-subject"
+          value={form.subject}
+          onChange={(e) => update('subject', e.target.value)}
+          aria-invalid={errors.subject ? 'true' : undefined}
+          disabled={submitting}
+        />
+        {errors.subject && <p className="contact-form__error" role="alert">{errors.subject}</p>}
+      </div>
+
+      <div className="contact-form__field">
+        <label htmlFor="contact-message">Message</label>
+        <textarea
+          id="contact-message"
+          rows={5}
+          value={form.message}
+          onChange={(e) => update('message', e.target.value)}
+          aria-invalid={errors.message ? 'true' : undefined}
+          disabled={submitting}
+        />
+        {errors.message && <p className="contact-form__error" role="alert">{errors.message}</p>}
+      </div>
+
+      {recaptchaSiteKey && (
+        <div
+          className="g-recaptcha"
+          data-sitekey={recaptchaSiteKey}
+          data-testid="recaptcha"
+        />
+      )}
+
+      {serverError && (
+        <p className="contact-form__error" role="alert">{serverError}</p>
+      )}
+
+      <button type="submit" disabled={submitting}>
+        {submitting ? 'Sending…' : 'Send message'}
+      </button>
+    </form>
+  )
+}
+
+export default ContactForm

--- a/web/src/test/ContactForm.test.tsx
+++ b/web/src/test/ContactForm.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { vi, describe, test, expect, beforeEach } from 'vitest'
+import { ContactForm } from '../components/ContactForm'
+import { post, ApiError } from '../api/client'
+
+vi.mock('../api/client', async () => {
+  const actual = await vi.importActual<typeof import('../api/client')>('../api/client')
+  return { ...actual, post: vi.fn() }
+})
+
+const mockedPost = post as unknown as ReturnType<typeof vi.fn>
+
+function fill(values: Partial<Record<string, string>>) {
+  if (values.name !== undefined)
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: values.name } })
+  if (values.email !== undefined)
+    fireEvent.change(screen.getByLabelText('Email'), { target: { value: values.email } })
+  if (values.subject !== undefined)
+    fireEvent.change(screen.getByLabelText('Subject'), { target: { value: values.subject } })
+  if (values.message !== undefined)
+    fireEvent.change(screen.getByLabelText('Message'), { target: { value: values.message } })
+}
+
+describe('ContactForm', () => {
+  beforeEach(() => {
+    mockedPost.mockReset()
+  })
+
+  test('renders all fields', () => {
+    render(<ContactForm />)
+    expect(screen.getByLabelText('Name')).toBeInTheDocument()
+    expect(screen.getByLabelText('Email')).toBeInTheDocument()
+    expect(screen.getByLabelText('Subject')).toBeInTheDocument()
+    expect(screen.getByLabelText('Message')).toBeInTheDocument()
+  })
+
+  test('shows validation errors and does not submit when empty', () => {
+    render(<ContactForm />)
+    fireEvent.click(screen.getByRole('button', { name: /send message/i }))
+    expect(screen.getByText('Name is required')).toBeInTheDocument()
+    expect(screen.getByText('Email is required')).toBeInTheDocument()
+    expect(screen.getByText('Subject is required')).toBeInTheDocument()
+    expect(screen.getByText('Message is required')).toBeInTheDocument()
+    expect(mockedPost).not.toHaveBeenCalled()
+  })
+
+  test('rejects an invalid email address', () => {
+    render(<ContactForm />)
+    fill({ name: 'Ada', email: 'bad-email', subject: 'Hi', message: 'Hello there' })
+    fireEvent.click(screen.getByRole('button', { name: /send message/i }))
+    expect(screen.getByText('Enter a valid email address')).toBeInTheDocument()
+    expect(mockedPost).not.toHaveBeenCalled()
+  })
+
+  test('submits valid data and shows the ticket reference', async () => {
+    mockedPost.mockResolvedValue({
+      message: 'received',
+      ticket: { reference: 'TKT-ABCD1234', status: 'open', created_at: '2026-01-01T00:00:00Z' },
+    })
+
+    render(<ContactForm />)
+    fill({ name: 'Ada', email: 'ada@example.com', subject: 'Help', message: 'I need help.' })
+    fireEvent.click(screen.getByRole('button', { name: /send message/i }))
+
+    await waitFor(() =>
+      expect(screen.getByTestId('ticket-reference')).toHaveTextContent('TKT-ABCD1234'),
+    )
+    expect(mockedPost).toHaveBeenCalledWith(
+      '/api/v1/contact',
+      expect.objectContaining({
+        name: 'Ada',
+        email: 'ada@example.com',
+        subject: 'Help',
+        message: 'I need help.',
+      }),
+    )
+  })
+
+  test('surfaces a server error', async () => {
+    mockedPost.mockRejectedValue(new ApiError(503, 'Service unavailable'))
+
+    render(<ContactForm />)
+    fill({ name: 'Ada', email: 'ada@example.com', subject: 'Help', message: 'I need help.' })
+    fireEvent.click(screen.getByRole('button', { name: /send message/i }))
+
+    await waitFor(() => expect(screen.getByText('Service unavailable')).toBeInTheDocument())
+  })
+})


### PR DESCRIPTION
## Summary
Implements a contact form so users can reach out for support and inquiries.

Closes #305

## Backend (`api`)
- **`POST /api/v1/contact`** — validates input, verifies reCAPTCHA (when configured), creates a **support ticket**, and sends a **support notification + auto-reply confirmation**.
- **`GET /api/v1/contact/tickets/{reference}`** — look up a ticket by reference.
- **`SupportTicket`** ORM model (`reference`, `name`, `email`, `subject`, `message`, `status`, `created_at`) registered on `Base.metadata`.
- **`services/recaptcha.py`** — Google `siteverify` (handles v3 score threshold); **disabled when no secret is set** so dev/test work without a key, and fails closed on transport errors.
- **`services/email.py`** — SendGrid via HTTP when `SENDGRID_API_KEY` is set, otherwise logs the message; **email failures never fail the submission** (best-effort).
- **Config** additions: `contact_recaptcha_secret`, `contact_recaptcha_min_score`, `sendgrid_api_key`, `contact_email_from`, `contact_support_email`.

## Frontend (`web`)
- **`ContactForm.tsx`** — name / email / subject / message with client-side validation, an optional reCAPTCHA widget (rendered when `VITE_RECAPTCHA_SITE_KEY` is set), submits via the API client, and shows the generated **ticket reference** on success.

## Requirements coverage
- [x] Contact form (name, email, subject, message)
- [x] Email notification on submission (support inbox)
- [x] Spam protection (reCAPTCHA verification)
- [x] Auto-reply confirmation
- [x] Support ticket generation (DB)

## Tests
- **API (8):** create→201 with ticket, invalid email / blank / missing field → 422, reCAPTCHA failure → 400, email dispatch invoked, ticket lookup, unknown → 404. Mirror the existing `api/tests` `client` fixture.
- **Web (5):** renders fields, validation blocks submit, invalid email, success shows ticket reference, server error surfaced. **All 5 pass.**

## Notes / scope decisions
- The contact endpoints are **email-provider agnostic**: SendGrid is wired via its HTTP API (no SDK dependency); the same `send_email` seam can back onto SES. Everything is **gated behind env config** and degrades to logging so no keys are required to run locally.
- `SupportTicket` is registered on `Base.metadata` like the other recent feature tables (FAQ, mentorship, notifications) — Alembic `--autogenerate` will include it; no hand-written migration added, consistent with those features.
- **Backend tests:** validated via `python -m py_compile` and written against the repo's `client` fixture, but I could not execute `pytest` locally — importing `api.app` pulls the full ML/OpenTelemetry dependency surface. They will run in CI. The **web tests were executed and pass**.