### PR TITLE
feat(feedback): in-app feedback collection with roadmap & GitHub integration

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -42,6 +42,7 @@ from api.routers import (
     contributors_router,
     errors_router,
     faq_router,
+    feedback_router,
     fraud_router,
     loyalty_router,
     mentorship_router,
@@ -160,6 +161,7 @@ app.include_router(mentorship_router)
 app.include_router(notifications_router)
 app.include_router(onboarding_router)
 app.include_router(faq_router)
+app.include_router(feedback_router)
 app.include_router(validation_router)
 app.include_router(backup_router)
 app.include_router(chat_router)

--- a/api/config.py
+++ b/api/config.py
@@ -48,5 +48,10 @@ class Settings(BaseSettings):
     contact_email_from: str = "no-reply@astroml.dev"
     contact_support_email: str = "support@astroml.dev"
 
+    # Feedback collection / GitHub integration (issue #308)
+    # When both are set, new feedback opens a GitHub issue in this repo.
+    github_token: str = ""
+    github_repo: str = ""  # "owner/repo"
+
 
 settings = Settings()

--- a/api/models/orm.py
+++ b/api/models/orm.py
@@ -566,5 +566,31 @@ class SupportTicket(Base):
     )
 
 
+class Feedback(Base):
+    """In-app user feedback: bug reports, feature requests, general comments (#308)."""
+
+    __tablename__ = "feedback"
+
+    id: Mapped[int] = mapped_column(_ID, primary_key=True, autoincrement=True)
+    category: Mapped[str] = mapped_column(String(16), nullable=False)  # bug|feature|general
+    message: Mapped[str] = mapped_column(Text, nullable=False)
+    email: Mapped[Optional[str]] = mapped_column(String(254))
+    # Optional screenshot stored as a data URL (data:image/png;base64,...).
+    screenshot: Mapped[Optional[str]] = mapped_column(Text)
+    # open|planned|in_progress|completed|declined — drives the public roadmap.
+    status: Mapped[str] = mapped_column(String(16), nullable=False, server_default="open")
+    github_issue_url: Mapped[Optional[str]] = mapped_column(String(512))
+    created_at: Mapped[datetime] = mapped_column(nullable=False, server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(
+        nullable=False, server_default=func.now(), onupdate=func.now()
+    )
+
+    __table_args__ = (
+        Index("ix_feedback_category", "category"),
+        Index("ix_feedback_status", "status"),
+        Index("ix_feedback_created_at", "created_at"),
+    )
+
+
 # Backward-compatible aliases removed — use ApiAccount / ApiTransaction to avoid
 # SQLAlchemy mapper name collisions with astroml.db.schema.

--- a/api/routers/__init__.py
+++ b/api/routers/__init__.py
@@ -7,6 +7,7 @@ from api.routers.chat import router as chat_router
 from api.routers.contact import router as contact_router
 from api.routers.errors import router as errors_router
 from api.routers.faq import router as faq_router
+from api.routers.feedback import router as feedback_router
 from api.routers.fraud import router as fraud_router
 from api.routers.loyalty import router as loyalty_router
 from api.routers.mentorship import router as mentorship_router
@@ -34,6 +35,7 @@ __all__ = [
     "auth_router",
     "errors_router",
     "faq_router",
+    "feedback_router",
     "fraud_router",
     "loyalty_router",
     "mentorship_router",

--- a/api/routers/feedback.py
+++ b/api/routers/feedback.py
@@ -1,0 +1,123 @@
+"""Feedback collection router (issue #308).
+
+Collects in-app feedback (bug / feature / general), optionally opens a GitHub
+issue, supports admin review (list + status updates), and exposes a public
+roadmap derived from feedback status.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api.database import get_db
+from api.models.orm import Feedback
+from api.schemas import (
+    FeedbackIn,
+    FeedbackListResponse,
+    FeedbackOut,
+    FeedbackStatusUpdate,
+    RoadmapResponse,
+    ROADMAP_STATUSES,
+)
+from api.services.github import create_feedback_issue
+
+router = APIRouter(prefix="/api/v1/feedback", tags=["feedback"])
+
+
+@router.post("", response_model=FeedbackOut, status_code=201)
+async def submit_feedback(
+    payload: FeedbackIn,
+    db: AsyncSession = Depends(get_db),
+) -> Feedback:
+    """Create a feedback item and (best-effort) open a GitHub issue."""
+    issue_url = None
+    try:
+        issue_url = await create_feedback_issue(
+            payload.category, payload.message, payload.email
+        )
+    except Exception:  # pragma: no cover - defensive; integration is best-effort
+        issue_url = None
+
+    feedback = Feedback(
+        category=payload.category,
+        message=payload.message,
+        email=payload.email,
+        screenshot=payload.screenshot,
+        status="open",
+        github_issue_url=issue_url,
+    )
+    db.add(feedback)
+    await db.commit()
+    await db.refresh(feedback)
+    return feedback
+
+
+@router.get("", response_model=FeedbackListResponse)
+async def list_feedback(
+    status: Optional[str] = None,
+    category: Optional[str] = None,
+    page: int = Query(1, ge=1),
+    page_size: int = Query(20, ge=1, le=100),
+    db: AsyncSession = Depends(get_db),
+) -> FeedbackListResponse:
+    """Admin: list feedback with optional status/category filters."""
+    query = select(Feedback)
+    count_query = select(func.count()).select_from(Feedback)
+    if status:
+        query = query.where(Feedback.status == status)
+        count_query = count_query.where(Feedback.status == status)
+    if category:
+        query = query.where(Feedback.category == category)
+        count_query = count_query.where(Feedback.category == category)
+
+    total = (await db.execute(count_query)).scalar_one()
+    query = query.order_by(Feedback.created_at.desc()).limit(page_size).offset(
+        (page - 1) * page_size
+    )
+    rows = (await db.execute(query)).scalars().all()
+    return FeedbackListResponse(
+        data=[FeedbackOut.model_validate(r) for r in rows],
+        page=page,
+        page_size=page_size,
+        total=total,
+    )
+
+
+@router.get("/roadmap", response_model=RoadmapResponse)
+async def roadmap(db: AsyncSession = Depends(get_db)) -> RoadmapResponse:
+    """Public roadmap: feedback grouped by planned / in_progress / completed."""
+    query = (
+        select(Feedback)
+        .where(Feedback.status.in_(ROADMAP_STATUSES))
+        .order_by(Feedback.created_at.desc())
+    )
+    rows = (await db.execute(query)).scalars().all()
+    grouped: dict[str, list] = {s: [] for s in ROADMAP_STATUSES}
+    for r in rows:
+        grouped[r.status].append(r)
+    return RoadmapResponse(
+        planned=grouped["planned"],
+        in_progress=grouped["in_progress"],
+        completed=grouped["completed"],
+    )
+
+
+@router.patch("/{feedback_id}", response_model=FeedbackOut)
+async def update_feedback_status(
+    feedback_id: int,
+    payload: FeedbackStatusUpdate,
+    db: AsyncSession = Depends(get_db),
+) -> Feedback:
+    """Admin: update a feedback item's status (drives the roadmap)."""
+    feedback = (
+        await db.execute(select(Feedback).where(Feedback.id == feedback_id))
+    ).scalar_one_or_none()
+    if feedback is None:
+        raise HTTPException(status_code=404, detail="Feedback not found")
+    feedback.status = payload.status
+    await db.commit()
+    await db.refresh(feedback)
+    return feedback

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -626,6 +626,91 @@ class SupportTicketOut(BaseModel):
         from_attributes = True
 
 
+# ─── Feedback (issue #308) ──────────────────────────────────────────────────
+
+FEEDBACK_CATEGORIES = {"bug", "feature", "general"}
+FEEDBACK_STATUSES = {"open", "planned", "in_progress", "completed", "declined"}
+ROADMAP_STATUSES = ("planned", "in_progress", "completed")
+
+
+class FeedbackIn(BaseModel):
+    category: str = Field(min_length=1, max_length=16)
+    message: str = Field(min_length=1, max_length=5000)
+    email: Optional[str] = Field(default=None, max_length=254)
+    screenshot: Optional[str] = None  # data URL: data:image/png;base64,...
+
+    @field_validator("category")
+    @classmethod
+    def _valid_category(cls, v: str) -> str:
+        v = v.strip().lower()
+        if v not in FEEDBACK_CATEGORIES:
+            raise ValueError("category must be one of: bug, feature, general")
+        return v
+
+    @field_validator("message")
+    @classmethod
+    def _not_blank(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("message must not be blank")
+        return v.strip()
+
+    @field_validator("screenshot")
+    @classmethod
+    def _valid_screenshot(cls, v: Optional[str]) -> Optional[str]:
+        if v is None:
+            return v
+        if not v.startswith("data:image/"):
+            raise ValueError("screenshot must be an image data URL")
+        return v
+
+
+class FeedbackOut(BaseModel):
+    id: int
+    category: str
+    message: str
+    status: str
+    github_issue_url: Optional[str] = None
+    created_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
 class ContactSubmitResponse(BaseModel):
     message: str
     ticket: SupportTicketOut
+
+
+class FeedbackListResponse(BaseModel):
+    data: List[FeedbackOut]
+    page: int
+    page_size: int
+    total: int
+
+
+class FeedbackStatusUpdate(BaseModel):
+    status: str
+
+    @field_validator("status")
+    @classmethod
+    def _valid_status(cls, v: str) -> str:
+        v = v.strip().lower()
+        if v not in FEEDBACK_STATUSES:
+            raise ValueError("invalid status")
+        return v
+
+
+class RoadmapItem(BaseModel):
+    id: int
+    category: str
+    message: str
+    status: str
+
+    class Config:
+        from_attributes = True
+
+
+class RoadmapResponse(BaseModel):
+    planned: List[RoadmapItem]
+    in_progress: List[RoadmapItem]
+    completed: List[RoadmapItem]

--- a/api/services/github.py
+++ b/api/services/github.py
@@ -1,0 +1,53 @@
+"""GitHub issue integration for feedback (issue #308).
+
+Opens a GitHub issue for incoming feedback when a token and repo are
+configured; otherwise it's a no-op so the feature works without credentials.
+"""
+from __future__ import annotations
+
+import logging
+
+import httpx
+
+from api.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+def github_configured() -> bool:
+    return bool(settings.github_token and settings.github_repo)
+
+
+async def create_feedback_issue(
+    category: str, message: str, email: str | None = None
+) -> str | None:
+    """Create a GitHub issue for the feedback. Returns the issue URL or None."""
+    if not github_configured():
+        logger.info("GitHub not configured; skipping issue creation")
+        return None
+
+    title = f"[feedback/{category}] {message[:60].strip()}"
+    body_lines = [message, "", f"_Category: {category}_"]
+    if email:
+        body_lines.append(f"_Reporter: {email}_")
+    payload = {
+        "title": title,
+        "body": "\n".join(body_lines),
+        "labels": ["feedback", category],
+    }
+    url = f"https://api.github.com/repos/{settings.github_repo}/issues"
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.post(
+                url,
+                json=payload,
+                headers={
+                    "Authorization": f"Bearer {settings.github_token}",
+                    "Accept": "application/vnd.github+json",
+                },
+            )
+        resp.raise_for_status()
+        return resp.json().get("html_url")
+    except Exception as exc:  # issue creation is best-effort
+        logger.warning("Failed to create GitHub issue: %s", exc)
+        return None

--- a/api/tests/test_feedback.py
+++ b/api/tests/test_feedback.py
@@ -1,0 +1,70 @@
+"""Tests for the feedback collection endpoints — issue #308."""
+from __future__ import annotations
+
+import pytest
+
+VALID = {"category": "bug", "message": "The chart fails to load on Safari."}
+
+
+@pytest.mark.xdist_group("api_feedback")
+class TestFeedback:
+    def test_submit_creates_feedback(self, client):
+        resp = client.post("/api/v1/feedback", json=VALID)
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["category"] == "bug"
+        assert data["status"] == "open"
+        assert data["id"] > 0
+
+    def test_submit_invalid_category_returns_422(self, client):
+        resp = client.post("/api/v1/feedback", json={**VALID, "category": "spam"})
+        assert resp.status_code == 422
+
+    def test_submit_blank_message_returns_422(self, client):
+        resp = client.post("/api/v1/feedback", json={**VALID, "message": "   "})
+        assert resp.status_code == 422
+
+    def test_submit_rejects_non_image_screenshot(self, client):
+        resp = client.post(
+            "/api/v1/feedback", json={**VALID, "screenshot": "not-a-data-url"}
+        )
+        assert resp.status_code == 422
+
+    def test_submit_accepts_image_data_url(self, client):
+        resp = client.post(
+            "/api/v1/feedback",
+            json={**VALID, "screenshot": "data:image/png;base64,AAAA"},
+        )
+        assert resp.status_code == 201
+
+    def test_list_and_filter_by_category(self, client):
+        client.post("/api/v1/feedback", json={"category": "bug", "message": "bug one"})
+        client.post("/api/v1/feedback", json={"category": "feature", "message": "feat one"})
+
+        resp = client.get("/api/v1/feedback?category=feature")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 1
+        assert data["data"][0]["category"] == "feature"
+
+    def test_update_status_and_roadmap(self, client):
+        fid = client.post(
+            "/api/v1/feedback", json={"category": "feature", "message": "dark mode"}
+        ).json()["id"]
+
+        # Not on the roadmap while status is "open".
+        assert client.get("/api/v1/feedback/roadmap").json()["planned"] == []
+
+        upd = client.patch(f"/api/v1/feedback/{fid}", json={"status": "planned"})
+        assert upd.status_code == 200
+        assert upd.json()["status"] == "planned"
+
+        roadmap = client.get("/api/v1/feedback/roadmap").json()
+        assert any(item["id"] == fid for item in roadmap["planned"])
+
+    def test_update_status_invalid_returns_422(self, client):
+        fid = client.post("/api/v1/feedback", json=VALID).json()["id"]
+        assert client.patch(f"/api/v1/feedback/{fid}", json={"status": "nope"}).status_code == 422
+
+    def test_update_unknown_feedback_returns_404(self, client):
+        assert client.patch("/api/v1/feedback/999999", json={"status": "planned"}).status_code == 404

--- a/web/src/components/Feedback.tsx
+++ b/web/src/components/Feedback.tsx
@@ -1,0 +1,162 @@
+/**
+ * Feedback (issue #308)
+ *
+ * In-app feedback panel for bug reports, feature requests, and general
+ * comments. Supports an optional screenshot attachment (read as a data URL)
+ * and submits to the feedback API.
+ */
+import React, { useState } from 'react'
+import { post, ApiError } from '../api/client'
+
+type Category = 'bug' | 'feature' | 'general'
+
+const CATEGORIES: { value: Category; label: string }[] = [
+  { value: 'bug', label: 'Bug report' },
+  { value: 'feature', label: 'Feature request' },
+  { value: 'general', label: 'General feedback' },
+]
+
+interface FeedbackResponse {
+  id: number
+  category: string
+  status: string
+}
+
+function readFileAsDataUrl(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => resolve(String(reader.result))
+    reader.onerror = () => reject(reader.error)
+    reader.readAsDataURL(file)
+  })
+}
+
+export function Feedback() {
+  const [category, setCategory] = useState<Category>('bug')
+  const [message, setMessage] = useState('')
+  const [email, setEmail] = useState('')
+  const [screenshot, setScreenshot] = useState<string | undefined>()
+  const [error, setError] = useState('')
+  const [status, setStatus] = useState<'idle' | 'submitting' | 'success'>('idle')
+
+  async function handleScreenshot(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0]
+    if (!file) {
+      setScreenshot(undefined)
+      return
+    }
+    try {
+      setScreenshot(await readFileAsDataUrl(file))
+    } catch {
+      setScreenshot(undefined)
+    }
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setError('')
+    if (!message.trim()) {
+      setError('Please enter your feedback')
+      return
+    }
+
+    setStatus('submitting')
+    try {
+      await post<FeedbackResponse>('/api/v1/feedback', {
+        category,
+        message: message.trim(),
+        email: email.trim() || undefined,
+        screenshot,
+      })
+      setStatus('success')
+      setMessage('')
+      setEmail('')
+      setScreenshot(undefined)
+    } catch (err) {
+      setStatus('idle')
+      setError(
+        err instanceof ApiError ? err.message : 'Could not submit feedback. Please try again.',
+      )
+    }
+  }
+
+  if (status === 'success') {
+    return (
+      <div className="feedback feedback--success" role="status">
+        <h3>Thanks for your feedback!</h3>
+        <p>We review every submission to help shape the roadmap.</p>
+        <button type="button" onClick={() => setStatus('idle')}>
+          Send more feedback
+        </button>
+      </div>
+    )
+  }
+
+  const submitting = status === 'submitting'
+
+  return (
+    <form className="feedback" onSubmit={handleSubmit} aria-label="Feedback form">
+      <h2>Send feedback</h2>
+
+      <fieldset className="feedback__categories">
+        <legend>Category</legend>
+        {CATEGORIES.map((c) => (
+          <label key={c.value}>
+            <input
+              type="radio"
+              name="feedback-category"
+              value={c.value}
+              checked={category === c.value}
+              onChange={() => setCategory(c.value)}
+              disabled={submitting}
+            />
+            {c.label}
+          </label>
+        ))}
+      </fieldset>
+
+      <div className="feedback__field">
+        <label htmlFor="feedback-message">Your feedback</label>
+        <textarea
+          id="feedback-message"
+          rows={5}
+          value={message}
+          onChange={(e) => setMessage(e.target.value)}
+          aria-invalid={error ? 'true' : undefined}
+          disabled={submitting}
+        />
+      </div>
+
+      <div className="feedback__field">
+        <label htmlFor="feedback-email">Email (optional)</label>
+        <input
+          id="feedback-email"
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          disabled={submitting}
+        />
+      </div>
+
+      <div className="feedback__field">
+        <label htmlFor="feedback-screenshot">Screenshot (optional)</label>
+        <input
+          id="feedback-screenshot"
+          type="file"
+          accept="image/*"
+          onChange={handleScreenshot}
+          disabled={submitting}
+        />
+        {screenshot && <span className="feedback__attached">Screenshot attached</span>}
+      </div>
+
+      {error && <p className="feedback__error" role="alert">{error}</p>}
+
+      <button type="submit" disabled={submitting}>
+        {submitting ? 'Sending…' : 'Send feedback'}
+      </button>
+    </form>
+  )
+}
+
+export default Feedback

--- a/web/src/test/Feedback.test.tsx
+++ b/web/src/test/Feedback.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { vi, describe, test, expect, beforeEach } from 'vitest'
+import { Feedback } from '../components/Feedback'
+import { post, ApiError } from '../api/client'
+
+vi.mock('../api/client', async () => {
+  const actual = await vi.importActual<typeof import('../api/client')>('../api/client')
+  return { ...actual, post: vi.fn() }
+})
+
+const mockedPost = post as unknown as ReturnType<typeof vi.fn>
+
+describe('Feedback', () => {
+  beforeEach(() => {
+    mockedPost.mockReset()
+  })
+
+  test('renders category options and the message field', () => {
+    render(<Feedback />)
+    expect(screen.getByLabelText('Bug report')).toBeInTheDocument()
+    expect(screen.getByLabelText('Feature request')).toBeInTheDocument()
+    expect(screen.getByLabelText('General feedback')).toBeInTheDocument()
+    expect(screen.getByLabelText('Your feedback')).toBeInTheDocument()
+  })
+
+  test('blocks submit when the message is empty', () => {
+    render(<Feedback />)
+    fireEvent.click(screen.getByRole('button', { name: /send feedback/i }))
+    expect(screen.getByText('Please enter your feedback')).toBeInTheDocument()
+    expect(mockedPost).not.toHaveBeenCalled()
+  })
+
+  test('submits the selected category and message, then shows success', async () => {
+    mockedPost.mockResolvedValue({ id: 1, category: 'feature', status: 'open' })
+
+    render(<Feedback />)
+    fireEvent.click(screen.getByLabelText('Feature request'))
+    fireEvent.change(screen.getByLabelText('Your feedback'), {
+      target: { value: 'Please add dark mode' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /send feedback/i }))
+
+    await waitFor(() => expect(screen.getByText(/thanks for your feedback/i)).toBeInTheDocument())
+    expect(mockedPost).toHaveBeenCalledWith(
+      '/api/v1/feedback',
+      expect.objectContaining({ category: 'feature', message: 'Please add dark mode' }),
+    )
+  })
+
+  test('surfaces a server error', async () => {
+    mockedPost.mockRejectedValue(new ApiError(500, 'Server exploded'))
+
+    render(<Feedback />)
+    fireEvent.change(screen.getByLabelText('Your feedback'), {
+      target: { value: 'Something broke' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /send feedback/i }))
+
+    await waitFor(() => expect(screen.getByText('Server exploded')).toBeInTheDocument())
+  })
+})


### PR DESCRIPTION
## Summary
Adds in-app feedback collection for user suggestions and bug reports.

Closes #308

## Backend (`api`)
- **`POST /api/v1/feedback`** — create feedback (`category` ∈ bug/feature/general, `message`, optional `email` + `screenshot` data URL). Best-effort opens a **GitHub issue** when a token/repo are configured and stores its URL.
- **`GET /api/v1/feedback`** — admin list with `status`/`category` filters + pagination.
- **`PATCH /api/v1/feedback/{id}`** — admin **status tracking** (open / planned / in_progress / completed / declined).
- **`GET /api/v1/feedback/roadmap`** — **public roadmap** grouped by planned / in_progress / completed.
- `Feedback` ORM model on `Base.metadata`; `services/github.py` issue creation is a no-op without credentials and never fails the request.

## Frontend (`web`)
- **`Feedback.tsx`** — category selection, message, optional email, optional **screenshot attachment** (read as a data URL), and a success state.

## Requirements coverage
- [x] Feedback modal/panel
- [x] Screenshot attachment
- [x] Category selection (bug, feature, general)
- [x] Feedback status tracking
- [x] Public roadmap integration (`/feedback/roadmap` + status-driven grouping)
- [x] GitHub issues integration (gated by config)

## Tests
- **API (9):** create, invalid category / blank message / non-image screenshot → 422, image data URL accepted, list filter by category, status update + roadmap reflection, unknown id → 404, invalid status → 422. Use the repo's `client` fixture.
- **Web (4):** renders categories + message, blocks empty submit, submits selected category + message → success, server error surfaced. **All 4 pass.**

## Notes / scope decisions
- Follows the same shape as the contact-form work: GitHub integration is **provider-gated** and degrades to a no-op so the feature runs locally without a token; screenshots are stored as data URLs (no blob storage dependency).
- `Feedback` is registered on `Base.metadata` like the other recent feature tables (FAQ, mentorship, notifications) — Alembic `--autogenerate` will pick it up; no hand-written migration, consistent with those features.
- The endpoints provide everything an **admin dashboard** and a **public roadmap page** need (list/filter/status + grouped roadmap); this PR focuses on the API + the user-facing feedback component. `FeedbackOut` intentionally omits `email`/`screenshot` to keep PII out of list responses.
- **Backend tests** validated via `py_compile` and written against the `client` fixture; I couldn't run `pytest` locally (importing `api.app` pulls the full ML/OpenTelemetry stack). They run in CI. **Web tests were executed and pass.**