### PR TITLE
feat: add LLM provider abstraction layer

### DIFF
--- a/astroml/llm/providers/anthropic.py
+++ b/astroml/llm/providers/anthropic.py
@@ -9,9 +9,23 @@ class AnthropicProvider(LLMProvider):
         self.last_usage = {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
 
     def generate(self, prompt: str, **kwargs: Any) -> str:
-        # Mock implementation for Anthropic generate
-        self.last_usage = {"prompt_tokens": 12, "completion_tokens": 18, "total_tokens": 30}
-        return f"Anthropic ({self.model}) response to: {prompt}"
+        import anthropic
+
+        client = anthropic.Anthropic(api_key=self.api_key)
+        max_tokens = kwargs.pop("max_tokens", 1024)
+        response = client.messages.create(
+            model=kwargs.pop("model", self.model),
+            max_tokens=max_tokens,
+            messages=[{"role": "user", "content": prompt}],
+            **kwargs,
+        )
+        if response.usage is not None:
+            self.last_usage = {
+                "prompt_tokens": response.usage.input_tokens,
+                "completion_tokens": response.usage.output_tokens,
+                "total_tokens": response.usage.input_tokens + response.usage.output_tokens,
+            }
+        return "".join(block.text for block in response.content if hasattr(block, "text"))
 
     def get_token_usage(self) -> Dict[str, int]:
         return self.last_usage

--- a/astroml/llm/providers/factory.py
+++ b/astroml/llm/providers/factory.py
@@ -22,9 +22,9 @@ def get_llm_provider(provider_name: str = None, **kwargs) -> LLMProvider:
     provider_class = _PROVIDERS[provider_name]
     
     # Extract API key based on provider
-    api_key = kwargs.get("api_key")
+    api_key = kwargs.pop("api_key", None)
     if not api_key:
         env_key = f"{provider_name.upper()}_API_KEY"
         api_key = os.getenv(env_key, f"mock-{provider_name}-key")
-    
+
     return provider_class(api_key=api_key, **kwargs)

--- a/astroml/llm/providers/huggingface.py
+++ b/astroml/llm/providers/huggingface.py
@@ -9,9 +9,20 @@ class HuggingFaceProvider(LLMProvider):
         self.last_usage = {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
 
     def generate(self, prompt: str, **kwargs: Any) -> str:
-        # Mock implementation for HuggingFace generate
-        self.last_usage = {"prompt_tokens": 15, "completion_tokens": 25, "total_tokens": 40}
-        return f"HuggingFace ({self.model}) response to: {prompt}"
+        from huggingface_hub import InferenceClient
+
+        client = InferenceClient(model=kwargs.pop("model", self.model), token=self.api_key)
+        text = client.text_generation(prompt, **kwargs)
+
+        # The inference API doesn't report usage, so approximate (~4 chars/token).
+        prompt_tokens = max(1, len(prompt) // 4)
+        completion_tokens = max(1, len(text) // 4)
+        self.last_usage = {
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "total_tokens": prompt_tokens + completion_tokens,
+        }
+        return text
 
     def get_token_usage(self) -> Dict[str, int]:
         return self.last_usage

--- a/astroml/llm/providers/openai.py
+++ b/astroml/llm/providers/openai.py
@@ -9,9 +9,21 @@ class OpenAIProvider(LLMProvider):
         self.last_usage = {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
 
     def generate(self, prompt: str, **kwargs: Any) -> str:
-        # Mock implementation for OpenAI generate
-        self.last_usage = {"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30}
-        return f"OpenAI ({self.model}) response to: {prompt}"
+        import openai
+
+        client = openai.OpenAI(api_key=self.api_key)
+        response = client.chat.completions.create(
+            model=kwargs.pop("model", self.model),
+            messages=[{"role": "user", "content": prompt}],
+            **kwargs,
+        )
+        if response.usage is not None:
+            self.last_usage = {
+                "prompt_tokens": response.usage.prompt_tokens,
+                "completion_tokens": response.usage.completion_tokens,
+                "total_tokens": response.usage.total_tokens,
+            }
+        return response.choices[0].message.content
 
     def get_token_usage(self) -> Dict[str, int]:
         return self.last_usage

--- a/astroml/llm/providers/test_providers.py
+++ b/astroml/llm/providers/test_providers.py
@@ -1,0 +1,100 @@
+"""Tests for the LLM provider abstraction layer (issue #359)."""
+import sys
+import types
+import unittest
+from unittest.mock import MagicMock
+
+from .factory import get_llm_provider, _PROVIDERS
+
+
+def _install_fake_module(name: str, **attrs):
+    module = types.ModuleType(name)
+    for key, value in attrs.items():
+        setattr(module, key, value)
+    sys.modules[name] = module
+    return module
+
+
+class FactoryTests(unittest.TestCase):
+    def test_unknown_provider_raises(self):
+        with self.assertRaises(ValueError):
+            get_llm_provider("not-a-provider")
+
+    def test_known_providers_registered(self):
+        self.assertEqual(set(_PROVIDERS), {"openai", "anthropic", "huggingface"})
+
+    def test_switch_provider_via_config_only(self):
+        import os
+
+        os.environ["LLM_PROVIDER"] = "anthropic"
+        try:
+            provider = get_llm_provider(api_key="sk-test")
+        finally:
+            del os.environ["LLM_PROVIDER"]
+        self.assertEqual(provider.__class__.__name__, "AnthropicProvider")
+
+
+class SameInterfaceTests(unittest.TestCase):
+    """Each provider must expose the same generate()/get_token_usage() interface."""
+
+    def setUp(self):
+        self._orig_modules = dict(sys.modules)
+
+    def tearDown(self):
+        sys.modules.clear()
+        sys.modules.update(self._orig_modules)
+
+    def test_openai_provider_generate(self):
+        fake_choice = MagicMock()
+        fake_choice.message.content = "hello from openai"
+        fake_response = MagicMock(choices=[fake_choice])
+        fake_response.usage.prompt_tokens = 5
+        fake_response.usage.completion_tokens = 7
+        fake_response.usage.total_tokens = 12
+        fake_client = MagicMock()
+        fake_client.chat.completions.create.return_value = fake_response
+        fake_openai = _install_fake_module("openai")
+        fake_openai.OpenAI = MagicMock(return_value=fake_client)
+
+        provider = get_llm_provider("openai", api_key="sk-test")
+        text = provider.generate("hi")
+
+        self.assertEqual(text, "hello from openai")
+        self.assertEqual(provider.get_token_usage(), {
+            "prompt_tokens": 5, "completion_tokens": 7, "total_tokens": 12,
+        })
+
+    def test_anthropic_provider_generate(self):
+        fake_block = MagicMock(text="hello from anthropic")
+        fake_response = MagicMock(content=[fake_block])
+        fake_response.usage.input_tokens = 6
+        fake_response.usage.output_tokens = 9
+        fake_client = MagicMock()
+        fake_client.messages.create.return_value = fake_response
+        fake_anthropic = _install_fake_module("anthropic")
+        fake_anthropic.Anthropic = MagicMock(return_value=fake_client)
+
+        provider = get_llm_provider("anthropic", api_key="sk-test")
+        text = provider.generate("hi")
+
+        self.assertEqual(text, "hello from anthropic")
+        self.assertEqual(provider.get_token_usage(), {
+            "prompt_tokens": 6, "completion_tokens": 9, "total_tokens": 15,
+        })
+
+    def test_huggingface_provider_generate(self):
+        fake_client = MagicMock()
+        fake_client.text_generation.return_value = "hello from huggingface"
+        fake_hf = _install_fake_module("huggingface_hub")
+        fake_hf.InferenceClient = MagicMock(return_value=fake_client)
+
+        provider = get_llm_provider("huggingface", api_key="hf-test")
+        text = provider.generate("hi")
+
+        self.assertEqual(text, "hello from huggingface")
+        usage = provider.get_token_usage()
+        self.assertEqual(usage["total_tokens"], usage["prompt_tokens"] + usage["completion_tokens"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- The existing `astroml/llm/providers/` scaffolding (base interface, factory, openai/anthropic/huggingface providers) already covered the interface/factory requirements, but `generate()` only returned hardcoded mock strings.
- Replace each provider's mock body with a real SDK call (`openai`, `anthropic`, `huggingface_hub`, lazily imported), keeping the existing `generate() -> str` / `get_token_usage() -> dict` interface so other callers (e.g. `FraudExplainer`) are unaffected.
- Fix a bug in `get_llm_provider()` where passing `api_key` as a kwarg caused a `TypeError` (duplicate `api_key` argument) — this also blocked switching providers via config in practice.

## Test plan
- [x] `python3 -m unittest astroml.llm.providers.test_providers` passes (6 tests, mocks each SDK to verify identical call interface and config-only switching)
- [x] `from astroml.llm.explainer import FraudExplainer` still imports cleanly (no regression for existing dependents)

Closes #359