### PR TITLE
feat: add LLM context management for blockchain data

### DIFF
--- a/astroml/llm/context.py
+++ b/astroml/llm/context.py
@@ -1,53 +1,90 @@
-import json
+"""LLM context management for blockchain data (issue #360)."""
 import logging
-from typing import Dict, Any, List
+from collections import defaultdict
 from datetime import datetime, timedelta
+from typing import Any, Dict, List
 
 logger = logging.getLogger(__name__)
 
+
 class BlockchainContextBuilder:
-    def __init__(self, token_limit: int = 4000):
+    """Packs blockchain transaction history into an LLM-ready context
+    string that fits within a token budget, compressing older days first.
+    """
+
+    def __init__(self, token_limit: int = 4000, recent_detailed_days: int = 7, group_size: int = 7):
         self.token_limit = token_limit
-        self.compression_ratio = 0.60
-        self.loss_threshold = 0.05
-    
+        self.recent_detailed_days = recent_detailed_days
+        self.group_size = group_size
+
     def analyze_token_size(self, data: str) -> int:
-        # Simple heuristic for token size analysis (approx 4 chars per token)
-        return len(data) // 4
-    
-    def compress_data(self, data: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-        # Simulate compression of blockchain transactions/data
-        # by removing non-essential fields (e.g. metadata, extra padding)
-        compressed = []
-        for item in data:
-            comp_item = {
-                'id': item.get('id', ''),
-                'amount': item.get('amount', 0),
-                'timestamp': item.get('timestamp', ''),
-                'from': item.get('from_address', '')[:10] + '...',
-                'to': item.get('to_address', '')[:10] + '...'
-            }
-            compressed.append(comp_item)
-        return compressed
-        
-    def build_context(self, days: int, raw_data: List[Dict[str, Any]]) -> str:
-        # Filter for the last N days
+        """Rough token estimate (~4 characters per token)."""
+        return max(1, len(data) // 4)
+
+    def summarize_by_day(self, days: int, raw_data: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """Group raw transactions from the last `days` days into daily summaries."""
         cutoff = datetime.now() - timedelta(days=days)
-        filtered = [
-            item for item in raw_data 
-            if datetime.fromisoformat(item.get('timestamp', datetime.now().isoformat())) >= cutoff
-        ]
-        
-        # Compress
-        compressed_data = self.compress_data(filtered)
-        
-        context_str = json.dumps(compressed_data)
-        
-        tokens = self.analyze_token_size(context_str)
-        if tokens > self.token_limit:
-            logger.warning(f"Context size ({tokens} tokens) exceeds limit ({self.token_limit}). Truncating.")
-            # Simple truncation for now to fit limit
-            truncated_chars = self.token_limit * 4
-            context_str = context_str[:truncated_chars]
-            
-        return context_str
+        by_day: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
+        for item in raw_data:
+            ts = datetime.fromisoformat(item.get("timestamp", datetime.now().isoformat()))
+            if ts >= cutoff:
+                by_day[ts.date().isoformat()].append(item)
+
+        summaries = []
+        for day, items in sorted(by_day.items()):
+            addresses = {item.get("from_address") for item in items} | {item.get("to_address") for item in items}
+            summaries.append({
+                "day": day,
+                "transaction_count": len(items),
+                "total_volume": sum(item.get("amount", 0) for item in items),
+                "unique_addresses": len(addresses - {None}),
+            })
+        return summaries
+
+    def _summary_to_text(self, summary: Dict[str, Any]) -> str:
+        return (
+            f"{summary['day']}: {summary['transaction_count']} txs, "
+            f"volume={summary['total_volume']:.2f}, unique_addresses={summary['unique_addresses']}"
+        )
+
+    def compress_data(self, summaries: List[Dict[str, Any]], group_size: int = None) -> str:
+        """Aggregate daily summaries into multi-day buckets, summing
+        transaction counts/volume exactly so totals don't drift.
+        """
+        group_size = group_size or self.group_size
+        lines = []
+        for i in range(0, len(summaries), group_size):
+            group = summaries[i:i + group_size]
+            start, end = group[0]["day"], group[-1]["day"]
+            tx_total = sum(s["transaction_count"] for s in group)
+            volume_total = sum(s["total_volume"] for s in group)
+            addresses_total = sum(s["unique_addresses"] for s in group)
+            lines.append(
+                f"{start}..{end} ({len(group)}d): {tx_total} txs, "
+                f"volume={volume_total:.2f}, unique_addresses~{addresses_total}"
+            )
+        return "\n".join(lines)
+
+    def build_context(self, days: int, raw_data: List[Dict[str, Any]]) -> str:
+        """Build a token-budgeted context string for the last `days` days
+        of blockchain activity, compressing older days if needed.
+        """
+        summaries = self.summarize_by_day(days, raw_data)
+
+        detailed_text = "\n".join(self._summary_to_text(s) for s in summaries)
+        if self.analyze_token_size(detailed_text) <= self.token_limit:
+            return detailed_text
+
+        cutoff = max(0, len(summaries) - self.recent_detailed_days)
+        older, recent = summaries[:cutoff], summaries[cutoff:]
+        recent_text = "\n".join(self._summary_to_text(s) for s in recent)
+
+        if not older:
+            return recent_text
+
+        context = self.compress_data(older) + ("\n" + recent_text if recent_text else "")
+        if self.analyze_token_size(context) <= self.token_limit:
+            return context
+
+        logger.warning("Context still exceeds token_limit=%d after compression; falling back to full aggregation.", self.token_limit)
+        return self.compress_data(summaries)

--- a/astroml/llm/test_context.py
+++ b/astroml/llm/test_context.py
@@ -1,0 +1,85 @@
+"""Tests for blockchain LLM context management (issue #360)."""
+import unittest
+from datetime import datetime, timedelta
+
+from .context import BlockchainContextBuilder
+
+
+def _make_raw_data(num_days: int, txs_per_day: int = 20) -> list:
+    now = datetime.now()
+    raw_data = []
+    for day in range(num_days):
+        ts = now - timedelta(days=day)
+        for tx in range(txs_per_day):
+            raw_data.append({
+                "id": f"d{day}-t{tx}",
+                "amount": 100.0 + tx,
+                "timestamp": ts.isoformat(),
+                "from_address": f"0xFrom{day}-{tx % 5}",
+                "to_address": f"0xTo{day}-{tx % 5}",
+            })
+    return raw_data
+
+
+class BlockchainContextBuilderTests(unittest.TestCase):
+    def test_30_days_fits_4k_token_budget(self):
+        raw_data = _make_raw_data(30)
+        builder = BlockchainContextBuilder(token_limit=4000)
+
+        context = builder.build_context(30, raw_data)
+
+        self.assertLessEqual(builder.analyze_token_size(context), 4000)
+
+    def test_small_input_stays_detailed(self):
+        raw_data = _make_raw_data(3)
+        builder = BlockchainContextBuilder(token_limit=4000)
+
+        context = builder.build_context(3, raw_data)
+        summaries = builder.summarize_by_day(3, raw_data)
+
+        for summary in summaries:
+            self.assertIn(summary["day"], context)
+
+
+class CompressDataTests(unittest.TestCase):
+    def test_compression_ratio_at_least_60_percent(self):
+        raw_data = _make_raw_data(30)
+        builder = BlockchainContextBuilder()
+        summaries = builder.summarize_by_day(30, raw_data)
+        detailed_text = "\n".join(builder._summary_to_text(s) for s in summaries)
+
+        compressed_text = builder.compress_data(summaries, group_size=7)
+
+        original_tokens = builder.analyze_token_size(detailed_text)
+        compressed_tokens = builder.analyze_token_size(compressed_text)
+        compression_ratio = 1 - (compressed_tokens / original_tokens)
+
+        self.assertGreaterEqual(compression_ratio, 0.6)
+
+    def test_compression_preserves_totals_within_5_percent(self):
+        raw_data = _make_raw_data(30)
+        builder = BlockchainContextBuilder()
+        summaries = builder.summarize_by_day(30, raw_data)
+        original_tx_total = sum(s["transaction_count"] for s in summaries)
+        original_volume_total = sum(s["total_volume"] for s in summaries)
+
+        compressed_text = builder.compress_data(summaries, group_size=7)
+
+        compressed_tx_total = sum(
+            int(line.split(" txs")[0].split()[-1])
+            for line in compressed_text.split("\n")
+        )
+        compressed_volume_total = sum(
+            float(line.split("volume=")[1].split(",")[0])
+            for line in compressed_text.split("\n")
+        )
+
+        tx_loss = abs(compressed_tx_total - original_tx_total) / original_tx_total
+        volume_loss = abs(compressed_volume_total - original_volume_total) / original_volume_total
+
+        self.assertLess(tx_loss, 0.05)
+        self.assertLess(volume_loss, 0.05)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- The existing `BlockchainContextBuilder` in `astroml/llm/context.py` only did naive JSON truncation, which could cut data mid-record and didn't actually compress (loses tail data unpredictably).
- Replace it with day-level summarization: `summarize_by_day()` aggregates raw transactions into daily stats (tx count, volume, unique addresses), `build_context()` keeps recent days detailed and compresses older days into multi-day buckets once the token budget is exceeded, and `compress_data()` aggregates buckets by summing counts/volume exactly (no precision loss on totals).
- Kept the existing class name/constructor (`BlockchainContextBuilder(token_limit=...)`) since nothing else in the repo depends on internal method behavior.

## Test plan
- [x] `python3 -m unittest astroml.llm.test_context` passes
- [x] 30 days of activity fit within a 4k token budget (`test_30_days_fits_4k_token_budget`)
- [x] Compression reduces tokens by >=60% with <5% loss on transaction/volume totals (`test_compression_ratio_at_least_60_percent`, `test_compression_preserves_totals_within_5_percent`)

Closes #360
