### PR TITLE
Add Automated Dependency Updates

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -63,6 +63,15 @@ jobs:
       # Issue #338: Run property-based tests with coverage reporting.
       run: pytest -v -m "not gpu" -p no:randomly --tb=short --cov=astroml --cov-report=xml --cov-report=term
 
+    - name: Upload coverage to Codecov
+      if: matrix.flavor == 'cpu'
+      uses: codecov/codecov-action@v4
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: ./coverage.xml
+        flags: py${{ matrix.python-version }}
+        fail_ci_if_error: false
+
     - name: Run pytest (GPU)
       if: matrix.flavor == 'gpu'
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,8 @@ node_modules/
 *.db
 *.sqlite
 *.sqlite3
+# Coverage
+.coverage
+.coverage.*
+coverage.xml
+htmlcov/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # AstroML
 //WIP
+
+[![CI](https://github.com/lordemaverick/astroml/actions/workflows/pytest.yml/badge.svg)](https://github.com/lordemaverick/astroml/actions/workflows/pytest.yml)
+[![codecov](https://codecov.io/gh/lordemaverick/astroml/branch/main/graph/badge.svg)](https://codecov.io/gh/lordemaverick/astroml)
+
 ## Dynamic Graph Machine Learning Framework for the Stellar Network
 
 **AstroML** is a research-driven Python framework for building **dynamic graph machine learning models** on the Stellar Development Foundation Stellar blockchain.

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,37 @@
+coverage:
+  precision: 2
+  round: down
+  range: "60...100"
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true
+    patch:
+      default:
+        target: 70%
+        informational: true
+
+comment:
+  layout: "reach,diff,flags,files"
+  behavior: default
+  require_changes: false
+
+ignore:
+  - "tests/**"
+  - "**/*_test.py"
+  - "test_*.py"
+  - "examples/**"
+  - "docs/**"
+  - "outputs/**"
+  - "k8s/**"
+  - "migrations/**"
+
+flags:
+  py3.10:
+    paths:
+      - astroml
+  py3.11:
+    paths:
+      - astroml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,3 +22,22 @@ markers = [
     "gpu: requires a CUDA-capable runner; auto-skipped on CPU-only environments",
     "e2e: end-to-end pipeline test (#193)",
 ]
+
+[tool.coverage.run]
+source = ["astroml"]
+branch = true
+omit = [
+    "*/tests/*",
+    "*/__init__.py",
+]
+
+[tool.coverage.report]
+precision = 2
+show_missing = true
+skip_covered = false
+exclude_lines = [
+    "pragma: no cover",
+    "raise NotImplementedError",
+    "if TYPE_CHECKING:",
+    "if __name__ == .__main__.:",
+]


### PR DESCRIPTION
Code Coverage Reporting (the actual gap — issue/PR templates and Dependabot already existed):
- .github/workflows/pytest.yml — added a Codecov upload step after the CPU test run, flagged per Python version, non-blocking if the token/service is unavailable.
- codecov.yml — coverage policy (informational status checks until a baseline exists, PR diff comments, ignored paths for tests/docs/generated dirs).
- pyproject.toml — added [tool.coverage.run]/[tool.coverage.report] sections (branch coverage, sensible omits/excludes).
- .gitignore — ignore .coverage, coverage.xml, htmlcov/.
- README.md — added CI and Codecov badges.

Note: the Codecov badge/upload will need a CODECOV_TOKEN secret added in the repo settings to fully activate (public repos often don't require one, but it's safest to add it). Since you asked me not to test, I haven't run the workflow or verified the badge renders — worth confirming once pushed.




closes #556
closes #554
closes #553
closes #555