### PR TITLE
feat: granular health checks, Prometheus metrics, DB pool health, and PR size limits [large PR]

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,6 +11,20 @@ Fixes # (issue)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] This change requires a documentation update
 
+## Size
+
+Keep pull requests reviewable: **≤ 1000 lines changed** and **≤ 10 files changed**.
+An automated check comments (but never fails CI) when a PR goes over.
+
+- [ ] This PR is within the size limits, **or** it is a planned large refactor
+      labelled `refactor:large` (≤ 50 files), **or** the title contains
+      `[large PR]` with a justification in the description.
+
+If it is too big: split it into a stack of smaller PRs, land refactors separately
+from behaviour changes, use a feature flag to merge incomplete work
+incrementally, and isolate generated/vendored files. See
+[docs/PR_SIZE_LIMITS.md](../docs/PR_SIZE_LIMITS.md).
+
 ## Checklist:
 
 - [ ] My code follows the style guidelines of this project

--- a/.github/workflows/pr-size-limit.yml
+++ b/.github/workflows/pr-size-limit.yml
@@ -1,0 +1,108 @@
+name: PR Size Limit
+
+# Soft enforcement (Issue #557): oversized pull requests get a warning
+# comment, never a failed check.
+#
+# `pull_request_target` is used so the comment step has write access on
+# pull requests opened from forks. No contributor code is checked out or
+# executed — only this repository's `astroml/ci/pr_size.py` runs, against
+# the event payload.
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, edited, labeled, unlabeled]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: pr-size-limit-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  size-check:
+    name: Check pull request size
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out base repository code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Evaluate pull request size
+        id: size
+        run: python -m astroml.ci.pr_size
+
+      - name: Post or update size warning
+        if: steps.size.outputs.should_comment == 'true'
+        uses: actions/github-script@v7
+        env:
+          COMMENT_BODY: ${{ steps.size.outputs.body }}
+        with:
+          script: |
+            const marker = '<!-- astroml:pr-size-limit -->';
+            const body = process.env.COMMENT_BODY;
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.pull_request.number;
+
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              { owner, repo, issue_number, per_page: 100 },
+            );
+            const existing = comments.find(
+              (comment) => comment.body && comment.body.includes(marker),
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner, repo, comment_id: existing.id, body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner, repo, issue_number, body,
+              });
+            }
+
+      - name: Resolve size warning
+        if: steps.size.outputs.should_comment != 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const marker = '<!-- astroml:pr-size-limit -->';
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.pull_request.number;
+
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              { owner, repo, issue_number, per_page: 100 },
+            );
+            const existing = comments.find(
+              (comment) => comment.body && comment.body.includes(marker),
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body: `${marker}\n### 📏 Pull request size\n\nThis pull request is within the review-friendly size limits. ✅`,
+              });
+            }
+
+      - name: Job summary
+        run: |
+          {
+            echo "### PR size check"
+            echo ""
+            echo "- exceeded: \`${{ steps.size.outputs.exceeded }}\`"
+            echo "- exempt (\`[large PR]\` in title): \`${{ steps.size.outputs.exempt }}\`"
+            echo ""
+            echo "Size never fails CI — see \`docs/PR_SIZE_LIMITS.md\`."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/api/app.py
+++ b/api/app.py
@@ -25,7 +25,6 @@ from typing import AsyncGenerator
 
 from fastapi import FastAPI, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
-from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
 
 from api.auth.middleware import AuthMiddleware
 from api.audit_middleware import AuditLoggingMiddleware
@@ -87,7 +86,10 @@ from api.routers.ws import poll_and_broadcast_transactions
 from api.websocket.llm import router as ws_llm_router
 from astroml.llm import metrics as _llm_metrics
 from api.routers import health
+from api.routers import healthz
 from api.routers import admin
+from astroml.observability.health import readiness_state
+from astroml.observability.metrics import observe_http_request, render_latest
 
 from strawberry.fastapi import GraphQLRouter
 from api.graphql.schema import schema
@@ -140,7 +142,13 @@ async def lifespan(application: FastAPI) -> AsyncGenerator[None, None]:
         except Exception:  # noqa: BLE001
             poll_task = None
 
+    # Startup finished — startup/readiness probes may now pass (issue #569).
+    readiness_state.mark_started()
+
     yield
+
+    # Drain traffic before dependencies are torn down.
+    readiness_state.set_ready(False, "Application is shutting down.")
 
     try:
         from astroml.api.scheduler import stop_scheduler  # noqa: PLC0415
@@ -176,12 +184,28 @@ app.add_middleware(
 )
 
 
+def _route_template(request: Request) -> str:
+    """Return the matched route path (not the raw URL) to bound cardinality."""
+    route = request.scope.get("route")
+    path = getattr(route, "path", None)
+    return path if isinstance(path, str) else request.url.path
+
+
 @app.middleware("http")
 async def _latency_middleware(request: Request, call_next):
     start = time.perf_counter()
-    response = await call_next(request)
-    record_latency((time.perf_counter() - start) * 1000)
-    return response
+    status_code = 500
+    try:
+        response = await call_next(request)
+        status_code = response.status_code
+        return response
+    finally:
+        elapsed = time.perf_counter() - start
+        record_latency(elapsed * 1000)
+        # Prometheus HTTP latency + request count (issue #567).
+        observe_http_request(
+            request.method, _route_template(request), status_code, elapsed
+        )
 
 
 # Include all routers from both branches
@@ -228,6 +252,7 @@ app.include_router(reports_router)
 app.include_router(alerts_router)
 # HEAD branch routers (health, admin, GraphQL)
 app.include_router(health.router)
+app.include_router(healthz.router)
 app.include_router(admin.router)
 app.include_router(graphql_app, prefix="/graphql")
 # upstream/main branch routers
@@ -250,7 +275,24 @@ async def health():
 
 @app.get("/metrics", tags=["ops"])
 async def prometheus_metrics():
-    return Response(generate_latest(), media_type=CONTENT_TYPE_LATEST)
+    """Prometheus exposition endpoint (issue #567)."""
+    _refresh_pool_gauges()
+    body, content_type = render_latest()
+    return Response(body, media_type=content_type)
+
+
+def _refresh_pool_gauges() -> None:
+    """Sample DB pool counters into the gauges just before a scrape (#550)."""
+    try:
+        from api.database import get_async_engine  # noqa: PLC0415
+        from astroml.db.pool_health import collect_pool_stats  # noqa: PLC0415
+        from astroml.observability.metrics import (  # noqa: PLC0415
+            update_db_pool_metrics,
+        )
+
+        update_db_pool_metrics(collect_pool_stats(get_async_engine()))
+    except Exception:  # noqa: BLE001 - a scrape must never 500
+        pass
 
 
 @app.get("/api/v1", tags=["ops"])

--- a/api/database.py
+++ b/api/database.py
@@ -213,6 +213,11 @@ def _sync_engine():
     )
 
 
+def get_async_engine():
+    """Return the shared async engine (used by health probes, issue #550)."""
+    return _async_engine()
+
+
 def reset_engines() -> None:
     """Clear cached engines (used in tests when DATABASE_URL changes)."""
     _async_engine.cache_clear()

--- a/api/routers/healthz.py
+++ b/api/routers/healthz.py
@@ -1,0 +1,318 @@
+"""Granular health check endpoints (Issue #569) and pool metrics (#550).
+
+Endpoints
+---------
+
+===========================  ==================================================
+``GET /healthz``             Aggregate status across every dependency.
+``GET /healthz/live``        Liveness — the process is running.
+``GET /healthz/startup``     Startup probe — initialisation finished.
+``GET /healthz/ready``       Readiness gate — safe to route traffic here.
+``GET /healthz/db``          Database connectivity plus pool saturation.
+``GET /healthz/cache``       Redis connectivity.
+``GET /healthz/disk``        Free disk space on the data volume.
+``GET /metrics/db-pool``     Connection pool utilization snapshot.
+===========================  ==================================================
+
+Every response uses the same JSON envelope::
+
+    {"status": "ok|degraded|fail", "details": {...}, "remediation": "..."}
+
+``fail`` is served with HTTP 503 so Kubernetes removes the pod from the
+Service endpoints; ``degraded`` stays on 200 because the instance can still
+serve traffic.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+from typing import Any, Awaitable, Callable, Final
+
+from fastapi import APIRouter
+from fastapi.responses import JSONResponse
+from sqlalchemy import text
+
+from api.database import get_async_engine, get_async_session_factory
+from astroml.db.pool_health import check_pool, collect_pool_stats
+from astroml.observability.health import (
+    HTTP_STATUS_FOR,
+    CheckResult,
+    HealthStatus,
+    aggregate_status,
+    check_disk,
+    readiness_state,
+)
+from astroml.observability.metrics import update_db_pool_metrics
+
+router = APIRouter(tags=["health"])
+
+#: Per-dependency probe timeout, seconds.
+CHECK_TIMEOUT_SECONDS: Final[float] = float(
+    os.environ.get("HEALTHZ_TIMEOUT_SECONDS", "5")
+)
+
+#: Path whose filesystem the disk probe inspects.
+DISK_PATH: Final[str] = os.environ.get("HEALTHZ_DISK_PATH", ".")
+
+#: When true, an unreachable cache fails readiness instead of degrading it.
+CACHE_REQUIRED: Final[bool] = os.environ.get(
+    "HEALTHZ_CACHE_REQUIRED", "false"
+).lower() in ("1", "true", "yes")
+
+
+def _envelope(result: CheckResult) -> JSONResponse:
+    """Serve a single check result with the matching HTTP status."""
+    return JSONResponse(status_code=result.http_status, content=result.to_dict())
+
+
+def _aggregate_envelope(results: list[CheckResult], *, probe: str) -> JSONResponse:
+    """Serve several check results as one aggregate response."""
+    status = aggregate_status(results)
+    remediation = " ".join(r.remediation for r in results if r.remediation)
+    body: dict[str, Any] = {
+        "status": status.value,
+        "probe": probe,
+        "details": {r.name: r.to_dict() for r in results},
+        "remediation": remediation,
+    }
+    return JSONResponse(status_code=HTTP_STATUS_FOR[status], content=body)
+
+
+async def _with_timeout(
+    name: str,
+    coro_factory: Callable[[], Awaitable[CheckResult]],
+    timeout: float = CHECK_TIMEOUT_SECONDS,
+) -> CheckResult:
+    """Run a check, converting timeouts and crashes into ``FAIL`` results."""
+    started = time.perf_counter()
+    try:
+        return await asyncio.wait_for(coro_factory(), timeout=timeout)
+    except asyncio.TimeoutError:
+        return CheckResult(
+            name=name,
+            status=HealthStatus.FAIL,
+            details={"error": f"timed out after {timeout}s"},
+            remediation=(
+                f"The {name} check exceeded {timeout}s. Check network "
+                "reachability and whether the dependency is saturated."
+            ),
+            duration_ms=(time.perf_counter() - started) * 1000,
+        )
+    except Exception as exc:  # noqa: BLE001 - a probe must always answer
+        return CheckResult(
+            name=name,
+            status=HealthStatus.FAIL,
+            details={"error": str(exc), "error_type": type(exc).__name__},
+            remediation=f"The {name} check raised an unexpected error: {exc}",
+            duration_ms=(time.perf_counter() - started) * 1000,
+        )
+
+
+# ─── Individual checks ───────────────────────────────────────────────────────
+
+
+async def check_database() -> CheckResult:
+    """Verify database connectivity and fold in pool saturation.
+
+    Returns:
+        A ``CheckResult`` named ``"db"``. ``FAIL`` when ``SELECT 1`` does not
+        succeed or the pool is exhausted; ``DEGRADED`` when the pool is above
+        the 80% utilization alert threshold.
+    """
+    started = time.perf_counter()
+    try:
+        async with get_async_session_factory()() as session:
+            await session.execute(text("SELECT 1"))
+    except Exception as exc:  # noqa: BLE001 - reported, not raised
+        return CheckResult(
+            name="db",
+            status=HealthStatus.FAIL,
+            details={"error": str(exc), "error_type": type(exc).__name__},
+            remediation=(
+                "The database is unreachable. Verify DATABASE_URL, that the "
+                "server accepts connections, and that credentials and network "
+                "policy allow this pod to connect."
+            ),
+            duration_ms=(time.perf_counter() - started) * 1000,
+        )
+
+    latency_ms = (time.perf_counter() - started) * 1000
+    pool_result = _pool_check()
+    details: dict[str, Any] = {
+        "latency_ms": round(latency_ms, 2),
+        "query": "SELECT 1",
+        "pool": dict(pool_result.details),
+    }
+
+    return CheckResult(
+        name="db",
+        status=pool_result.status,
+        details=details,
+        remediation=pool_result.remediation,
+        duration_ms=latency_ms,
+    )
+
+
+def _pool_check() -> CheckResult:
+    """Inspect the async engine's pool and refresh the Prometheus gauges."""
+    engine = get_async_engine()
+    stats = collect_pool_stats(engine)
+    update_db_pool_metrics(stats)
+    return check_pool(engine)
+
+
+def _ping_redis(url: str) -> float:
+    """Ping Redis synchronously, returning the round-trip time in ms."""
+    import redis  # noqa: PLC0415 - optional dependency, imported lazily
+
+    client = redis.Redis.from_url(
+        url,
+        socket_connect_timeout=CHECK_TIMEOUT_SECONDS,
+        socket_timeout=CHECK_TIMEOUT_SECONDS,
+    )
+    try:
+        started = time.perf_counter()
+        client.ping()
+        return (time.perf_counter() - started) * 1000
+    finally:
+        client.close()
+
+
+async def check_cache() -> CheckResult:
+    """Verify Redis connectivity.
+
+    A cache outage is reported as ``DEGRADED`` (the API serves traffic
+    without a cache) unless ``HEALTHZ_CACHE_REQUIRED`` is set, in which case
+    it is ``FAIL`` and readiness drops.
+
+    Returns:
+        A ``CheckResult`` named ``"cache"``.
+    """
+    url = os.environ.get("REDIS_URL", "redis://localhost:6379/0")
+    started = time.perf_counter()
+    failure_status = HealthStatus.FAIL if CACHE_REQUIRED else HealthStatus.DEGRADED
+
+    try:
+        latency_ms = await asyncio.to_thread(_ping_redis, url)
+    except Exception as exc:  # noqa: BLE001 - reported, not raised
+        return CheckResult(
+            name="cache",
+            status=failure_status,
+            details={
+                "error": str(exc),
+                "error_type": type(exc).__name__,
+                "required": CACHE_REQUIRED,
+            },
+            remediation=(
+                "Redis is unreachable. Verify REDIS_URL, that the Redis "
+                "service is running, and that it is not evicting under "
+                "memory pressure. Cached reads will fall through to the "
+                "database until this recovers."
+            ),
+            duration_ms=(time.perf_counter() - started) * 1000,
+        )
+
+    return CheckResult(
+        name="cache",
+        status=HealthStatus.OK,
+        details={"latency_ms": round(latency_ms, 2), "required": CACHE_REQUIRED},
+        duration_ms=(time.perf_counter() - started) * 1000,
+    )
+
+
+async def check_disk_space() -> CheckResult:
+    """Check free space on the configured data volume."""
+    return await asyncio.to_thread(check_disk, DISK_PATH)
+
+
+# ─── Routes ──────────────────────────────────────────────────────────────────
+
+
+@router.get("/healthz", summary="Aggregate health across all dependencies")
+async def healthz() -> JSONResponse:
+    """Return the combined status of every dependency."""
+    results = await asyncio.gather(
+        _with_timeout("db", check_database),
+        _with_timeout("cache", check_cache),
+        _with_timeout("disk", check_disk_space),
+    )
+    return _aggregate_envelope([readiness_state.snapshot(), *results], probe="healthz")
+
+
+@router.get("/healthz/live", summary="Liveness probe")
+async def healthz_live() -> JSONResponse:
+    """Return 200 whenever the process can serve a request.
+
+    Deliberately checks nothing external: a failing dependency must not get
+    the container restarted.
+    """
+    return _envelope(
+        CheckResult(
+            name="live",
+            status=HealthStatus.OK,
+            details={"uptime_seconds": round(readiness_state.uptime_seconds, 2)},
+        )
+    )
+
+
+@router.get("/healthz/startup", summary="Startup probe")
+async def healthz_startup() -> JSONResponse:
+    """Return 200 once application startup has completed."""
+    return _envelope(readiness_state.snapshot())
+
+
+@router.get("/healthz/ready", summary="Readiness probe")
+async def healthz_ready() -> JSONResponse:
+    """Gate traffic on startup completion and hard dependencies.
+
+    The database is a hard dependency; the cache and disk checks can only
+    downgrade readiness to ``degraded`` (still 200) unless they fail
+    outright.
+    """
+    startup = readiness_state.snapshot()
+    if startup.status is HealthStatus.FAIL:
+        return _aggregate_envelope([startup], probe="ready")
+
+    results = await asyncio.gather(
+        _with_timeout("db", check_database),
+        _with_timeout("cache", check_cache),
+        _with_timeout("disk", check_disk_space),
+    )
+    return _aggregate_envelope([startup, *results], probe="ready")
+
+
+@router.get("/healthz/db", summary="Database connectivity probe")
+async def healthz_db() -> JSONResponse:
+    """Check database connectivity and connection pool saturation."""
+    return _envelope(await _with_timeout("db", check_database))
+
+
+@router.get("/healthz/cache", summary="Redis connectivity probe")
+async def healthz_cache() -> JSONResponse:
+    """Check Redis connectivity."""
+    return _envelope(await _with_timeout("cache", check_cache))
+
+
+@router.get("/healthz/disk", summary="Disk space probe")
+async def healthz_disk() -> JSONResponse:
+    """Check free space on the data volume."""
+    return _envelope(await _with_timeout("disk", check_disk_space))
+
+
+@router.get("/metrics/db-pool", summary="Connection pool utilization")
+async def db_pool_metrics() -> JSONResponse:
+    """Return the connection pool snapshot as JSON.
+
+    The same numbers are exported to Prometheus as ``db_pool_size`` and
+    ``db_pool_utilization_ratio``; this endpoint exists for quick operator
+    inspection without a Prometheus round trip.
+    """
+    result = _pool_check()
+    body = {
+        "status": result.status.value,
+        "pool": dict(result.details),
+        "remediation": result.remediation,
+    }
+    return JSONResponse(status_code=HTTP_STATUS_FOR[result.status], content=body)

--- a/astroml/ci/__init__.py
+++ b/astroml/ci/__init__.py
@@ -1,0 +1,19 @@
+"""CI helper utilities that run inside GitHub Actions workflows."""
+
+from astroml.ci.pr_size import (
+    DEFAULT_THRESHOLDS,
+    PullRequestStats,
+    SizeThresholds,
+    SizeVerdict,
+    evaluate_pr_size,
+    render_comment,
+)
+
+__all__ = [
+    "DEFAULT_THRESHOLDS",
+    "PullRequestStats",
+    "SizeThresholds",
+    "SizeVerdict",
+    "evaluate_pr_size",
+    "render_comment",
+]

--- a/astroml/ci/pr_size.py
+++ b/astroml/ci/pr_size.py
@@ -1,0 +1,313 @@
+"""Pull request size evaluation (Issue #557).
+
+Large pull requests are harder to review and carry more merge risk. This
+module implements the *soft* enforcement policy used by the
+``pr-size-limit`` GitHub Actions workflow:
+
+* a PR over the thresholds gets a warning comment,
+* CI is never failed because of size alone,
+* ``refactor:large`` raises the file-count ceiling for planned refactors,
+* ``[large PR]`` in the title opts out of the check entirely.
+
+The evaluation logic lives here (rather than inline in ``github-script``)
+so it is type-checked by ``mypy`` and covered by unit tests. The workflow
+invokes it as ``python -m astroml.ci.pr_size``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from dataclasses import dataclass, field
+from typing import Any, Final, Iterable, Sequence
+
+#: Marker used to find (and update) the bot's previous size comment.
+COMMENT_MARKER: Final[str] = "<!-- astroml:pr-size-limit -->"
+
+#: Title opt-out token. Case-insensitive.
+TITLE_EXEMPTION: Final[str] = "[large pr]"
+
+#: Label that raises the file-count ceiling for planned large refactors.
+LARGE_REFACTOR_LABEL: Final[str] = "refactor:large"
+
+
+@dataclass(frozen=True)
+class SizeThresholds:
+    """Limits a pull request is measured against.
+
+    Attributes:
+        max_lines: Maximum combined additions + deletions.
+        max_files: Maximum number of changed files.
+        max_files_large_refactor: File ceiling when the PR carries the
+            ``refactor:large`` label.
+    """
+
+    max_lines: int = 1000
+    max_files: int = 10
+    max_files_large_refactor: int = 50
+
+    def file_limit(self, *, large_refactor: bool) -> int:
+        """Return the applicable file ceiling for this PR."""
+        return self.max_files_large_refactor if large_refactor else self.max_files
+
+
+DEFAULT_THRESHOLDS: Final[SizeThresholds] = SizeThresholds()
+
+
+@dataclass(frozen=True)
+class PullRequestStats:
+    """Measured size of a pull request.
+
+    Attributes:
+        additions: Lines added.
+        deletions: Lines removed.
+        changed_files: Number of files touched.
+        title: Pull request title, used for the ``[large PR]`` opt-out.
+        labels: Label names attached to the pull request.
+    """
+
+    additions: int
+    deletions: int
+    changed_files: int
+    title: str = ""
+    labels: Sequence[str] = field(default_factory=tuple)
+
+    @property
+    def total_lines(self) -> int:
+        """Combined additions and deletions."""
+        return self.additions + self.deletions
+
+    @classmethod
+    def from_event(cls, payload: dict[str, Any]) -> "PullRequestStats":
+        """Build stats from a GitHub ``pull_request`` event payload.
+
+        Args:
+            payload: The full webhook payload, or the ``pull_request``
+                object itself.
+
+        Returns:
+            Parsed :class:`PullRequestStats`.
+
+        Raises:
+            ValueError: If no ``pull_request`` object can be located.
+        """
+        pull_request = payload.get("pull_request", payload)
+        if not isinstance(pull_request, dict) or "changed_files" not in pull_request:
+            raise ValueError(
+                "Event payload does not contain a pull_request object with "
+                "size fields (additions/deletions/changed_files)."
+            )
+
+        raw_labels = pull_request.get("labels") or []
+        labels = tuple(_label_names(raw_labels))
+
+        return cls(
+            additions=int(pull_request.get("additions", 0)),
+            deletions=int(pull_request.get("deletions", 0)),
+            changed_files=int(pull_request.get("changed_files", 0)),
+            title=str(pull_request.get("title", "")),
+            labels=labels,
+        )
+
+
+def _label_names(raw_labels: Iterable[Any]) -> list[str]:
+    """Normalise GitHub label objects (or plain strings) to lowercase names."""
+    names: list[str] = []
+    for label in raw_labels:
+        if isinstance(label, dict):
+            name = label.get("name")
+        else:
+            name = label
+        if isinstance(name, str):
+            names.append(name.strip().lower())
+    return names
+
+
+@dataclass(frozen=True)
+class SizeVerdict:
+    """Outcome of a size evaluation.
+
+    Attributes:
+        exceeded: True when at least one applicable limit was exceeded.
+        exempt: True when the ``[large PR]`` title opt-out applies.
+        large_refactor: True when the ``refactor:large`` label applies.
+        reasons: Human-readable descriptions of each breached limit.
+        stats: The stats that were evaluated.
+        thresholds: The thresholds that were applied.
+    """
+
+    exceeded: bool
+    exempt: bool
+    large_refactor: bool
+    reasons: tuple[str, ...]
+    stats: PullRequestStats
+    thresholds: SizeThresholds
+
+    @property
+    def should_comment(self) -> bool:
+        """True when a warning comment should be posted."""
+        return self.exceeded and not self.exempt
+
+
+def is_exempt(title: str) -> bool:
+    """Return True when the PR title opts out of the size check."""
+    return TITLE_EXEMPTION in title.lower()
+
+
+def has_large_refactor_label(labels: Sequence[str]) -> bool:
+    """Return True when the ``refactor:large`` label is present."""
+    return LARGE_REFACTOR_LABEL in {label.strip().lower() for label in labels}
+
+
+def evaluate_pr_size(
+    stats: PullRequestStats,
+    thresholds: SizeThresholds = DEFAULT_THRESHOLDS,
+) -> SizeVerdict:
+    """Compare a pull request against the size policy.
+
+    Args:
+        stats: Measured pull request size.
+        thresholds: Limits to apply. Defaults to :data:`DEFAULT_THRESHOLDS`.
+
+    Returns:
+        A :class:`SizeVerdict` describing which limits (if any) were breached.
+    """
+    exempt = is_exempt(stats.title)
+    large_refactor = has_large_refactor_label(stats.labels)
+    file_limit = thresholds.file_limit(large_refactor=large_refactor)
+
+    reasons: list[str] = []
+    if stats.total_lines > thresholds.max_lines:
+        reasons.append(
+            f"{stats.total_lines} lines changed "
+            f"(+{stats.additions}/-{stats.deletions}) exceeds the "
+            f"{thresholds.max_lines}-line limit."
+        )
+    if stats.changed_files > file_limit:
+        suffix = " for `refactor:large` pull requests" if large_refactor else ""
+        reasons.append(
+            f"{stats.changed_files} files changed exceeds the "
+            f"{file_limit}-file limit{suffix}."
+        )
+
+    return SizeVerdict(
+        exceeded=bool(reasons),
+        exempt=exempt,
+        large_refactor=large_refactor,
+        reasons=tuple(reasons),
+        stats=stats,
+        thresholds=thresholds,
+    )
+
+
+def render_comment(verdict: SizeVerdict) -> str:
+    """Render the warning comment body for an oversized pull request.
+
+    Args:
+        verdict: Result of :func:`evaluate_pr_size`.
+
+    Returns:
+        Markdown body, prefixed with :data:`COMMENT_MARKER` so the workflow
+        can update its previous comment instead of posting duplicates.
+    """
+    stats = verdict.stats
+    file_limit = verdict.thresholds.file_limit(large_refactor=verdict.large_refactor)
+
+    lines = [
+        COMMENT_MARKER,
+        "### 📏 Pull request size warning",
+        "",
+        "This pull request exceeds the review-friendly size limits. "
+        "**CI is not blocked** — this is guidance, not a gate.",
+        "",
+        "| Metric | This PR | Limit |",
+        "| --- | ---: | ---: |",
+        f"| Lines changed | {stats.total_lines} | {verdict.thresholds.max_lines} |",
+        f"| Files changed | {stats.changed_files} | {file_limit} |",
+        "",
+        "**Why it matters**",
+        "",
+        "Review quality drops sharply with diff size: defects slip through, "
+        "review turnaround grows, and reverts become riskier because unrelated "
+        "changes are bundled together.",
+        "",
+        "**What to do**",
+        "",
+        "- Split the change into a stack of smaller, independently reviewable PRs.",
+        "- Land refactors and behaviour changes separately.",
+        "- Hide incomplete work behind a feature flag and merge it incrementally.",
+        "- Move generated files, lockfiles, or vendored code into their own PR.",
+        "",
+        "**Legitimately large?**",
+        "",
+        f"- Add the `{LARGE_REFACTOR_LABEL}` label to raise the file ceiling to "
+        f"{verdict.thresholds.max_files_large_refactor} files.",
+        "- Add `[large PR]` to the title to skip this check entirely.",
+        "",
+        "<details><summary>Breached limits</summary>",
+        "",
+    ]
+    lines.extend(f"- {reason}" for reason in verdict.reasons)
+    lines.extend(["", "</details>"])
+    return "\n".join(lines)
+
+
+def _write_github_output(verdict: SizeVerdict, path: str) -> None:
+    """Append workflow outputs to the ``$GITHUB_OUTPUT`` file."""
+    body = render_comment(verdict) if verdict.should_comment else ""
+    with open(path, "a", encoding="utf-8") as handle:
+        handle.write(f"exceeded={'true' if verdict.exceeded else 'false'}\n")
+        handle.write(f"exempt={'true' if verdict.exempt else 'false'}\n")
+        handle.write(
+            f"should_comment={'true' if verdict.should_comment else 'false'}\n"
+        )
+        handle.write("body<<PR_SIZE_EOF\n")
+        handle.write(f"{body}\n")
+        handle.write("PR_SIZE_EOF\n")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Entry point used by the ``pr-size-limit`` workflow.
+
+    Reads the event payload from ``GITHUB_EVENT_PATH`` (or the first CLI
+    argument) and writes ``exceeded``, ``exempt``, ``should_comment`` and
+    ``body`` to ``$GITHUB_OUTPUT``.
+
+    Args:
+        argv: Optional argument vector, defaults to ``sys.argv[1:]``.
+
+    Returns:
+        Process exit code. Always ``0`` on a successful evaluation — size
+        alone never fails CI.
+    """
+    args = list(sys.argv[1:] if argv is None else argv)
+    event_path = args[0] if args else os.environ.get("GITHUB_EVENT_PATH", "")
+    if not event_path:
+        print("No event payload available (GITHUB_EVENT_PATH unset).", file=sys.stderr)
+        return 1
+
+    with open(event_path, encoding="utf-8") as handle:
+        payload = json.load(handle)
+
+    verdict = evaluate_pr_size(PullRequestStats.from_event(payload))
+
+    summary = (
+        f"lines={verdict.stats.total_lines} "
+        f"files={verdict.stats.changed_files} "
+        f"exceeded={verdict.exceeded} exempt={verdict.exempt} "
+        f"large_refactor={verdict.large_refactor}"
+    )
+    print(summary)
+    for reason in verdict.reasons:
+        print(f"  - {reason}")
+
+    output_path = os.environ.get("GITHUB_OUTPUT")
+    if output_path:
+        _write_github_output(verdict, output_path)
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/astroml/db/pool_health.py
+++ b/astroml/db/pool_health.py
@@ -1,0 +1,190 @@
+"""Connection pool health inspection (Issue #550).
+
+SQLAlchemy's ``QueuePool`` exposes counters but no policy: this module turns
+those counters into a typed :class:`PoolStats` snapshot with a utilization
+ratio, an alert threshold, and operator remediation text. The result feeds
+both ``GET /metrics/db-pool`` and the ``/healthz/db`` probe.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Any, Final
+
+from sqlalchemy.engine import Engine
+from sqlalchemy.pool import Pool
+
+from astroml.observability.health import CheckResult, HealthStatus
+
+#: Utilization ratio at or above which the pool is considered saturated.
+POOL_UTILIZATION_ALERT_THRESHOLD: Final[float] = 0.80
+
+
+@dataclass(frozen=True)
+class PoolStats:
+    """Snapshot of a SQLAlchemy connection pool.
+
+    Attributes:
+        pool_size: Configured steady-state pool size.
+        checked_in: Idle connections currently held by the pool.
+        checked_out: Connections currently leased to the application.
+        overflow: Connections created beyond ``pool_size``. SQLAlchemy
+            reports a negative number when overflow headroom is unused; it
+            is clamped to ``0`` here.
+        max_overflow: Configured overflow allowance.
+        implementation: Pool class name, e.g. ``"QueuePool"``.
+    """
+
+    pool_size: int
+    checked_in: int
+    checked_out: int
+    overflow: int
+    max_overflow: int
+    implementation: str
+
+    @property
+    def capacity(self) -> int:
+        """Maximum simultaneous connections (``pool_size + max_overflow``)."""
+        return self.pool_size + self.max_overflow
+
+    @property
+    def utilization(self) -> float:
+        """Checked-out connections as a ratio of :attr:`capacity`."""
+        if self.capacity <= 0:
+            return 0.0
+        return min(self.checked_out / self.capacity, 1.0)
+
+    @property
+    def saturated(self) -> bool:
+        """True when utilization reaches the alert threshold."""
+        return self.utilization >= POOL_UTILIZATION_ALERT_THRESHOLD
+
+    @property
+    def exhausted(self) -> bool:
+        """True when every connection slot is leased out."""
+        return self.capacity > 0 and self.checked_out >= self.capacity
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise for the ``/metrics/db-pool`` JSON response."""
+        return {
+            "implementation": self.implementation,
+            "pool_size": self.pool_size,
+            "checked_in": self.checked_in,
+            "checked_out": self.checked_out,
+            "overflow": self.overflow,
+            "max_overflow": self.max_overflow,
+            "capacity": self.capacity,
+            "utilization": round(self.utilization, 4),
+            "utilization_percent": round(self.utilization * 100, 2),
+            "alert_threshold_percent": round(POOL_UTILIZATION_ALERT_THRESHOLD * 100, 2),
+            "saturated": self.saturated,
+            "exhausted": self.exhausted,
+        }
+
+
+def _int_attr(pool: Pool | Any, name: str) -> int:
+    """Read an optional integer counter off a pool implementation.
+
+    ``NullPool`` and ``StaticPool`` (used by SQLite in tests) do not
+    implement the ``QueuePool`` counters; missing counters read as ``0``.
+    """
+    getter = getattr(pool, name, None)
+    if getter is None:
+        return 0
+    try:
+        value = getter() if callable(getter) else getter
+    except Exception:  # noqa: BLE001 - counters must never break a probe
+        return 0
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def collect_pool_stats(engine: Engine | Any) -> PoolStats:
+    """Read pool counters from a sync or async SQLAlchemy engine.
+
+    Args:
+        engine: An ``Engine``, ``AsyncEngine``, or any object exposing a
+            ``pool`` attribute.
+
+    Returns:
+        A :class:`PoolStats` snapshot. Pools without counters (``NullPool``,
+        ``StaticPool``) report zeros rather than raising.
+    """
+    pool = getattr(getattr(engine, "sync_engine", engine), "pool", engine)
+
+    overflow = _int_attr(pool, "overflow")
+    max_overflow = _int_attr(pool, "_max_overflow")
+
+    return PoolStats(
+        pool_size=_int_attr(pool, "size"),
+        checked_in=_int_attr(pool, "checkedin"),
+        checked_out=_int_attr(pool, "checkedout"),
+        overflow=max(overflow, 0),
+        max_overflow=max(max_overflow, 0),
+        implementation=type(pool).__name__,
+    )
+
+
+def evaluate_pool_health(stats: PoolStats) -> CheckResult:
+    """Classify a pool snapshot and attach remediation guidance.
+
+    Args:
+        stats: Pool snapshot from :func:`collect_pool_stats`.
+
+    Returns:
+        A :class:`CheckResult` named ``"db_pool"``. Saturation is reported
+        as ``DEGRADED`` (the service still works); full exhaustion is
+        ``FAIL`` because new requests will block until ``pool_timeout``.
+    """
+    if stats.exhausted:
+        return CheckResult(
+            name="db_pool",
+            status=HealthStatus.FAIL,
+            details=stats.to_dict(),
+            remediation=(
+                f"All {stats.capacity} connections are checked out. New "
+                "requests will block until pool_timeout expires. Look for "
+                "sessions that are never closed, raise DB_POOL_MAX_SIZE / "
+                "DB_POOL_MAX_OVERFLOW, or shed load."
+            ),
+        )
+    if stats.saturated:
+        return CheckResult(
+            name="db_pool",
+            status=HealthStatus.DEGRADED,
+            details=stats.to_dict(),
+            remediation=(
+                f"Pool utilization is {stats.utilization:.0%}, at or above "
+                f"the {POOL_UTILIZATION_ALERT_THRESHOLD:.0%} alert "
+                "threshold. Check for slow queries holding connections and "
+                "consider raising DB_POOL_MAX_SIZE before it exhausts."
+            ),
+        )
+    return CheckResult(
+        name="db_pool",
+        status=HealthStatus.OK,
+        details=stats.to_dict(),
+    )
+
+
+def check_pool(engine: Engine | Any) -> CheckResult:
+    """Collect and evaluate pool health in one call.
+
+    Args:
+        engine: Engine whose pool should be inspected.
+
+    Returns:
+        A :class:`CheckResult` named ``"db_pool"``, with ``duration_ms`` set.
+    """
+    started = time.perf_counter()
+    result = evaluate_pool_health(collect_pool_stats(engine))
+    return CheckResult(
+        name=result.name,
+        status=result.status,
+        details=result.details,
+        remediation=result.remediation,
+        duration_ms=(time.perf_counter() - started) * 1000,
+    )

--- a/astroml/db/session.py
+++ b/astroml/db/session.py
@@ -10,13 +10,17 @@ from __future__ import annotations
 import os
 import pathlib
 from functools import lru_cache
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 import yaml
 from pydantic import BaseModel, Field, ValidationError, field_validator
 from sqlalchemy import create_engine
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session, sessionmaker
+
+if TYPE_CHECKING:  # pragma: no cover - import cycle guard
+    from astroml.db.pool_health import PoolStats
+    from astroml.observability.health import CheckResult
 
 
 class DatabaseConfig(BaseModel):
@@ -176,3 +180,22 @@ def get_session() -> Session:
     """Return a new SQLAlchemy session."""
     factory = sessionmaker(bind=get_engine())
     return factory()
+
+
+def get_pool_stats() -> "PoolStats":
+    """Return a snapshot of the shared engine's connection pool (#550)."""
+    from astroml.db.pool_health import collect_pool_stats
+
+    return collect_pool_stats(get_engine())
+
+
+def check_connection_pool() -> "CheckResult":
+    """Evaluate connection pool health for the shared engine (#550).
+
+    Returns:
+        A ``CheckResult`` named ``"db_pool"`` — ``DEGRADED`` once utilization
+        reaches 80% of capacity, ``FAIL`` when the pool is exhausted.
+    """
+    from astroml.db.pool_health import check_pool
+
+    return check_pool(get_engine())

--- a/astroml/features/feature_engine.py
+++ b/astroml/features/feature_engine.py
@@ -692,9 +692,13 @@ class ComputationEngine:
             **kwargs
         )
         
+        from astroml.observability.metrics import FEATURE_COMPUTE_TIME
+
         self.submit_task(task)
-        completed_tasks = self.run_tasks(parallel=False)
-        
+        # Feature computation time (issue #567).
+        with FEATURE_COMPUTE_TIME.labels(feature_name).time():
+            completed_tasks = self.run_tasks(parallel=False)
+
         if task.task_id not in completed_tasks:
             raise RuntimeError(f"Task {task.task_id} not found in completed tasks")
         

--- a/astroml/ingestion/service.py
+++ b/astroml/ingestion/service.py
@@ -149,31 +149,43 @@ class IngestionService:
         fetch = fetch_fn or (lambda ledger_id: {"ledger": ledger_id})
         process = process_fn or (lambda ledger_id, payload: None)
 
+        from astroml.observability.metrics import track_active_job
+
         pending_flush = 0
         try:
-            for offset, ledger_id in enumerate(range(start_ledger, end_ledger + 1), start=1):
-                if ledger_id in processed_set:
-                    yield ledger_id, LedgerOutcome(ledger_id=ledger_id, status="skipped")
-                else:
-                    payload = fetch(ledger_id)
-                    process(ledger_id, payload)
-                    processed_set.add(ledger_id)
-                    state.last_processed_ledger = (
-                        ledger_id
-                        if state.last_processed_ledger is None
-                        else max(state.last_processed_ledger, ledger_id)
-                    )
-                    pending_flush += 1
-                    if pending_flush >= batch_size:
-                        self.state.save(state)
-                        pending_flush = 0
-                    yield ledger_id, LedgerOutcome(ledger_id=ledger_id, status="processed")
+            # Active ingestion jobs gauge (issue #567). Entering the context
+            # here keeps the gauge balanced even if the caller abandons the
+            # generator partway through — GeneratorExit unwinds this `with`.
+            with track_active_job("ingestion"):
+                for offset, ledger_id in enumerate(
+                    range(start_ledger, end_ledger + 1), start=1
+                ):
+                    if ledger_id in processed_set:
+                        yield ledger_id, LedgerOutcome(
+                            ledger_id=ledger_id, status="skipped"
+                        )
+                    else:
+                        payload = fetch(ledger_id)
+                        process(ledger_id, payload)
+                        processed_set.add(ledger_id)
+                        state.last_processed_ledger = (
+                            ledger_id
+                            if state.last_processed_ledger is None
+                            else max(state.last_processed_ledger, ledger_id)
+                        )
+                        pending_flush += 1
+                        if pending_flush >= batch_size:
+                            self.state.save(state)
+                            pending_flush = 0
+                        yield ledger_id, LedgerOutcome(
+                            ledger_id=ledger_id, status="processed"
+                        )
 
-                if offset % batch_size == 0:
-                    logger.info(
-                        "ingest_stream progress: %d/%d ledgers (up to %d)",
-                        offset, end_ledger - start_ledger + 1, ledger_id,
-                    )
+                    if offset % batch_size == 0:
+                        logger.info(
+                            "ingest_stream progress: %d/%d ledgers (up to %d)",
+                            offset, end_ledger - start_ledger + 1, ledger_id,
+                        )
         finally:
             if pending_flush:
                 self.state.save(state)

--- a/astroml/models/deep_svdd.py
+++ b/astroml/models/deep_svdd.py
@@ -88,8 +88,11 @@ class DeepSVDD(nn.Module, BaseEstimator):
     
     def predict(self, x: torch.Tensor) -> torch.Tensor:
         """Predict anomaly scores."""
+        from astroml.observability.metrics import MODEL_INFERENCE_LATENCY
+
         self.eval()
-        with torch.no_grad():
+        # Model inference latency (issue #567).
+        with MODEL_INFERENCE_LATENCY.labels("deep_svdd").time(), torch.no_grad():
             x = x.to(self.device).float()
             embeddings = self.network(x)
             distances = torch.sum((embeddings - self.center) ** 2, dim=1)

--- a/astroml/observability/__init__.py
+++ b/astroml/observability/__init__.py
@@ -1,0 +1,57 @@
+"""Operational observability primitives: health checks and Prometheus metrics.
+
+Two independent surfaces live here:
+
+* :mod:`astroml.observability.health` — transport-agnostic health check
+  results used by the ``/healthz/*`` endpoints (Issue #569).
+* :mod:`astroml.observability.metrics` — the Prometheus metric registry and
+  the decorators used to instrument critical paths (Issue #567).
+"""
+
+from astroml.observability.health import (
+    CheckResult,
+    HealthStatus,
+    ReadinessState,
+    aggregate_status,
+    check_disk,
+    readiness_state,
+)
+from astroml.observability.metrics import (
+    ACTIVE_JOBS,
+    DB_POOL_SIZE,
+    DB_POOL_UTILIZATION,
+    FEATURE_COMPUTE_TIME,
+    HTTP_REQUEST_DURATION,
+    HTTP_REQUESTS_TOTAL,
+    MODEL_INFERENCE_LATENCY,
+    observe_http_request,
+    render_latest,
+    track_active_job,
+    track_feature_compute,
+    track_inference,
+    track_time,
+    update_db_pool_metrics,
+)
+
+__all__ = [
+    "ACTIVE_JOBS",
+    "CheckResult",
+    "DB_POOL_SIZE",
+    "DB_POOL_UTILIZATION",
+    "FEATURE_COMPUTE_TIME",
+    "HTTP_REQUESTS_TOTAL",
+    "HTTP_REQUEST_DURATION",
+    "HealthStatus",
+    "MODEL_INFERENCE_LATENCY",
+    "ReadinessState",
+    "aggregate_status",
+    "check_disk",
+    "observe_http_request",
+    "readiness_state",
+    "render_latest",
+    "track_active_job",
+    "track_feature_compute",
+    "track_inference",
+    "track_time",
+    "update_db_pool_metrics",
+]

--- a/astroml/observability/health.py
+++ b/astroml/observability/health.py
@@ -1,0 +1,293 @@
+"""Transport-agnostic health check primitives (Issue #569).
+
+The FastAPI routers in ``api/routers/healthz.py`` are thin wrappers around
+the types defined here, so the health semantics (status vocabulary,
+aggregation rules, remediation text, readiness gating) are unit-testable
+without an HTTP client or live dependencies.
+"""
+
+from __future__ import annotations
+
+import shutil
+import time
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Final, Iterable, Mapping
+
+
+class HealthStatus(str, Enum):
+    """Status vocabulary shared by every health check.
+
+    ``OK`` — the component is fully functional.
+    ``DEGRADED`` — the component works but is close to a limit; traffic is
+    still served.
+    ``FAIL`` — the component is unusable; readiness must not pass.
+    """
+
+    OK = "ok"
+    DEGRADED = "degraded"
+    FAIL = "fail"
+
+    @property
+    def is_serving(self) -> bool:
+        """True when a component in this state can still serve traffic."""
+        return self is not HealthStatus.FAIL
+
+
+#: Severity ordering used when aggregating multiple checks.
+_SEVERITY: Final[dict[HealthStatus, int]] = {
+    HealthStatus.OK: 0,
+    HealthStatus.DEGRADED: 1,
+    HealthStatus.FAIL: 2,
+}
+
+#: HTTP status code returned for each health status.
+HTTP_STATUS_FOR: Final[dict[HealthStatus, int]] = {
+    HealthStatus.OK: 200,
+    HealthStatus.DEGRADED: 200,
+    HealthStatus.FAIL: 503,
+}
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    """Outcome of a single component health check.
+
+    Attributes:
+        name: Component name, e.g. ``"db"``.
+        status: Health status of the component.
+        details: Structured, component-specific measurements.
+        remediation: Operator-facing next step. Empty when status is ``OK``.
+        duration_ms: Wall-clock duration of the check.
+    """
+
+    name: str
+    status: HealthStatus
+    details: Mapping[str, Any] = field(default_factory=dict)
+    remediation: str = ""
+    duration_ms: float = 0.0
+
+    @property
+    def http_status(self) -> int:
+        """HTTP status code this result should be served with."""
+        return HTTP_STATUS_FOR[self.status]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise to the JSON body shape used by the ``/healthz`` API."""
+        return {
+            "status": self.status.value,
+            "component": self.name,
+            "details": dict(self.details),
+            "remediation": self.remediation,
+            "duration_ms": round(self.duration_ms, 2),
+        }
+
+
+def aggregate_status(results: Iterable[CheckResult]) -> HealthStatus:
+    """Reduce several check results to the worst status observed.
+
+    Args:
+        results: Individual component results.
+
+    Returns:
+        ``OK`` for an empty iterable, otherwise the most severe status.
+    """
+    worst = HealthStatus.OK
+    for result in results:
+        if _SEVERITY[result.status] > _SEVERITY[worst]:
+            worst = result.status
+    return worst
+
+
+def aggregate_to_dict(
+    results: Iterable[CheckResult],
+    *,
+    remediation_prefix: str = "",
+) -> dict[str, Any]:
+    """Build the aggregate JSON body for a multi-component probe.
+
+    Args:
+        results: Individual component results.
+        remediation_prefix: Optional sentence prepended to the combined
+            remediation text.
+
+    Returns:
+        A mapping with ``status``, per-component ``details`` and a combined
+        ``remediation`` string.
+    """
+    materialised = list(results)
+    status = aggregate_status(materialised)
+    remediations = [r.remediation for r in materialised if r.remediation]
+    remediation = " ".join(filter(None, [remediation_prefix, *remediations]))
+
+    return {
+        "status": status.value,
+        "details": {r.name: r.to_dict() for r in materialised},
+        "remediation": remediation,
+    }
+
+
+#: Free-space ratio below which the disk check reports ``DEGRADED``.
+DISK_DEGRADED_RATIO: Final[float] = 0.20
+
+#: Free-space ratio below which the disk check reports ``FAIL``.
+DISK_FAIL_RATIO: Final[float] = 0.10
+
+
+def check_disk(
+    path: str = ".",
+    *,
+    degraded_ratio: float = DISK_DEGRADED_RATIO,
+    fail_ratio: float = DISK_FAIL_RATIO,
+) -> CheckResult:
+    """Check free disk space on the filesystem backing ``path``.
+
+    Args:
+        path: Any path on the filesystem to inspect.
+        degraded_ratio: Free-space ratio below which status is ``DEGRADED``.
+        fail_ratio: Free-space ratio below which status is ``FAIL``.
+
+    Returns:
+        A :class:`CheckResult` named ``"disk"``.
+    """
+    started = time.perf_counter()
+    try:
+        usage = shutil.disk_usage(path)
+    except OSError as exc:
+        return CheckResult(
+            name="disk",
+            status=HealthStatus.FAIL,
+            details={"path": path, "error": str(exc)},
+            remediation=(
+                f"Cannot stat {path}. Verify the volume is mounted and the "
+                "process user has read access."
+            ),
+            duration_ms=(time.perf_counter() - started) * 1000,
+        )
+
+    free_ratio = usage.free / usage.total if usage.total else 0.0
+    if free_ratio < fail_ratio:
+        status = HealthStatus.FAIL
+        remediation = (
+            f"Only {free_ratio:.1%} of {path} is free. Free space immediately "
+            "— prune model artifacts, rotate logs, or expand the volume; "
+            "writes will start failing."
+        )
+    elif free_ratio < degraded_ratio:
+        status = HealthStatus.DEGRADED
+        remediation = (
+            f"{free_ratio:.1%} of {path} is free, below the "
+            f"{degraded_ratio:.0%} warning threshold. Schedule cleanup of "
+            "artifacts and logs before it becomes critical."
+        )
+    else:
+        status = HealthStatus.OK
+        remediation = ""
+
+    return CheckResult(
+        name="disk",
+        status=status,
+        details={
+            "path": path,
+            "total_bytes": usage.total,
+            "used_bytes": usage.used,
+            "free_bytes": usage.free,
+            "free_ratio": round(free_ratio, 4),
+            "degraded_ratio": degraded_ratio,
+            "fail_ratio": fail_ratio,
+        },
+        remediation=remediation,
+        duration_ms=(time.perf_counter() - started) * 1000,
+    )
+
+
+class ReadinessState:
+    """Tracks whether the process has finished initialising.
+
+    Kubernetes startup probes poll :meth:`snapshot` until ``started`` is
+    true; readiness probes additionally require dependency checks to pass.
+    Readiness can be flipped off manually (``set_ready(False)``) to drain a
+    pod before shutdown.
+    """
+
+    def __init__(self) -> None:
+        self._started_at: float | None = None
+        self._ready: bool = False
+        self._detail: str = "Process has not completed startup."
+
+    def mark_started(self, detail: str = "Startup complete.") -> None:
+        """Record that application startup finished."""
+        self._started_at = time.time()
+        self._ready = True
+        self._detail = detail
+
+    def set_ready(self, ready: bool, detail: str = "") -> None:
+        """Manually gate readiness, e.g. to drain traffic before shutdown."""
+        self._ready = ready
+        self._detail = detail or (
+            "Ready." if ready else "Readiness disabled by operator."
+        )
+
+    def reset(self) -> None:
+        """Return to the pre-startup state (used by tests)."""
+        self._started_at = None
+        self._ready = False
+        self._detail = "Process has not completed startup."
+
+    @property
+    def started(self) -> bool:
+        """True once :meth:`mark_started` has been called."""
+        return self._started_at is not None
+
+    @property
+    def ready(self) -> bool:
+        """True when startup finished and readiness has not been revoked."""
+        return self.started and self._ready
+
+    @property
+    def uptime_seconds(self) -> float:
+        """Seconds since startup completed; ``0.0`` before that."""
+        if self._started_at is None:
+            return 0.0
+        return time.time() - self._started_at
+
+    def snapshot(self) -> CheckResult:
+        """Return the startup gate as a :class:`CheckResult`."""
+        if not self.started:
+            return CheckResult(
+                name="startup",
+                status=HealthStatus.FAIL,
+                details={"started": False, "ready": False},
+                remediation=(
+                    "The application is still initialising. If this persists "
+                    "past the startup probe budget, inspect the container "
+                    "logs for a stalled lifespan handler."
+                ),
+            )
+        if not self._ready:
+            return CheckResult(
+                name="startup",
+                status=HealthStatus.FAIL,
+                details={
+                    "started": True,
+                    "ready": False,
+                    "uptime_seconds": round(self.uptime_seconds, 2),
+                },
+                remediation=(
+                    f"{self._detail} Traffic is being drained; this is "
+                    "expected during a graceful shutdown."
+                ),
+            )
+        return CheckResult(
+            name="startup",
+            status=HealthStatus.OK,
+            details={
+                "started": True,
+                "ready": True,
+                "uptime_seconds": round(self.uptime_seconds, 2),
+            },
+        )
+
+
+#: Process-wide readiness gate used by the API lifespan and probes.
+readiness_state: Final[ReadinessState] = ReadinessState()

--- a/astroml/observability/metrics.py
+++ b/astroml/observability/metrics.py
@@ -1,0 +1,288 @@
+"""Prometheus metrics for critical AstroML paths (Issue #567).
+
+Metric reference
+----------------
+
+==============================  =========  ==================================
+Name                            Type       Labels
+==============================  =========  ==================================
+http_request_duration_seconds   Histogram  method, endpoint, status
+http_requests_total             Counter    method, endpoint, status
+db_pool_size                    Gauge      pool, state
+db_pool_utilization_ratio       Gauge      pool
+feature_compute_time            Histogram  feature
+model_inference_latency         Histogram  model
+active_jobs                     Gauge      job_type
+==============================  =========  ==================================
+
+Instrumentation helpers
+-----------------------
+
+``track_time`` wraps sync *or* async callables and records into any
+histogram. ``track_feature_compute`` / ``track_inference`` are the
+pre-bound variants for the feature and model paths, and ``track_active_job``
+is a context manager that keeps the ``active_jobs`` gauge balanced even when
+the job raises.
+"""
+
+from __future__ import annotations
+
+import functools
+import inspect
+import time
+from contextlib import contextmanager
+from typing import Any, Awaitable, Callable, Final, Iterator, TypeVar, cast
+
+from prometheus_client import (
+    CONTENT_TYPE_LATEST,
+    REGISTRY,
+    Counter,
+    Gauge,
+    Histogram,
+    generate_latest,
+)
+from prometheus_client.metrics import MetricWrapperBase
+from prometheus_client.registry import CollectorRegistry
+
+F = TypeVar("F", bound=Callable[..., Any])
+T = TypeVar("T")
+
+#: Latency buckets tuned for sub-second API work with a long tail.
+LATENCY_BUCKETS: Final[tuple[float, ...]] = (
+    0.005,
+    0.01,
+    0.025,
+    0.05,
+    0.1,
+    0.25,
+    0.5,
+    1.0,
+    2.5,
+    5.0,
+    10.0,
+    30.0,
+)
+
+
+def _get_or_create(
+    metric_cls: type[MetricWrapperBase],
+    name: str,
+    documentation: str,
+    labelnames: tuple[str, ...] = (),
+    registry: CollectorRegistry = REGISTRY,
+    **kwargs: Any,
+) -> Any:
+    """Return an existing collector by name, or register a new one.
+
+    Module reloads (common under pytest) would otherwise raise
+    ``Duplicated timeseries in CollectorRegistry``.
+
+    Args:
+        metric_cls: ``Counter``, ``Gauge`` or ``Histogram``.
+        name: Metric name.
+        documentation: HELP text.
+        labelnames: Label names for the metric.
+        registry: Registry to look in. Defaults to the global registry.
+        **kwargs: Extra keyword arguments for the metric constructor.
+
+    Returns:
+        The registered collector.
+    """
+    existing = registry._names_to_collectors.get(name)  # noqa: SLF001
+    if existing is not None:
+        return existing
+    return metric_cls(
+        name,
+        documentation,
+        labelnames,
+        registry=registry,
+        **kwargs,
+    )
+
+
+HTTP_REQUEST_DURATION: Final[Histogram] = _get_or_create(
+    Histogram,
+    "http_request_duration_seconds",
+    "HTTP request latency in seconds.",
+    ("method", "endpoint", "status"),
+    buckets=LATENCY_BUCKETS,
+)
+
+HTTP_REQUESTS_TOTAL: Final[Counter] = _get_or_create(
+    Counter,
+    "http_requests_total",
+    "Total HTTP requests by endpoint and response status.",
+    ("method", "endpoint", "status"),
+)
+
+DB_POOL_SIZE: Final[Gauge] = _get_or_create(
+    Gauge,
+    "db_pool_size",
+    (
+        "Database connection pool connections by state "
+        "(configured, in_use, idle, overflow, capacity)."
+    ),
+    ("pool", "state"),
+)
+
+DB_POOL_UTILIZATION: Final[Gauge] = _get_or_create(
+    Gauge,
+    "db_pool_utilization_ratio",
+    "Database connection pool utilization as a ratio of total capacity.",
+    ("pool",),
+)
+
+FEATURE_COMPUTE_TIME: Final[Histogram] = _get_or_create(
+    Histogram,
+    "feature_compute_time",
+    "Feature computation time in seconds.",
+    ("feature",),
+    buckets=LATENCY_BUCKETS,
+)
+
+MODEL_INFERENCE_LATENCY: Final[Histogram] = _get_or_create(
+    Histogram,
+    "model_inference_latency",
+    "Model inference latency in seconds.",
+    ("model",),
+    buckets=LATENCY_BUCKETS,
+)
+
+ACTIVE_JOBS: Final[Gauge] = _get_or_create(
+    Gauge,
+    "active_jobs",
+    "Number of jobs currently running, by job type (e.g. ingestion).",
+    ("job_type",),
+)
+
+
+def observe_http_request(
+    method: str,
+    endpoint: str,
+    status_code: int,
+    duration_seconds: float,
+) -> None:
+    """Record one HTTP request in both the latency histogram and counter.
+
+    Args:
+        method: HTTP method, e.g. ``"GET"``.
+        endpoint: Route template (not the raw path) to keep cardinality low.
+        status_code: Response status code.
+        duration_seconds: Request duration in seconds.
+    """
+    labels = (method.upper(), endpoint, str(status_code))
+    HTTP_REQUEST_DURATION.labels(*labels).observe(duration_seconds)
+    HTTP_REQUESTS_TOTAL.labels(*labels).inc()
+
+
+def update_db_pool_metrics(stats: Any, pool_name: str = "default") -> None:
+    """Publish connection pool statistics to the pool gauges.
+
+    Args:
+        stats: An :class:`astroml.db.pool_health.PoolStats` instance (any
+            object exposing the same attributes works).
+        pool_name: Label distinguishing multiple pools.
+    """
+    DB_POOL_SIZE.labels(pool_name, "configured").set(stats.pool_size)
+    DB_POOL_SIZE.labels(pool_name, "in_use").set(stats.checked_out)
+    DB_POOL_SIZE.labels(pool_name, "idle").set(stats.checked_in)
+    DB_POOL_SIZE.labels(pool_name, "overflow").set(stats.overflow)
+    DB_POOL_SIZE.labels(pool_name, "capacity").set(stats.capacity)
+    DB_POOL_UTILIZATION.labels(pool_name).set(stats.utilization)
+
+
+def track_time(histogram: Histogram, *label_values: str) -> Callable[[F], F]:
+    """Decorate a sync or async callable, timing it into ``histogram``.
+
+    Args:
+        histogram: Target histogram.
+        *label_values: Label values, in the histogram's label order.
+
+    Returns:
+        A decorator preserving the wrapped function's signature.
+
+    Example:
+        >>> from astroml.observability.metrics import FEATURE_COMPUTE_TIME
+        >>> @track_time(FEATURE_COMPUTE_TIME, "degree_centrality")
+        ... def compute() -> int:
+        ...     return 1
+        >>> compute()
+        1
+    """
+    target = histogram.labels(*label_values) if label_values else histogram
+
+    def decorator(func: F) -> F:
+        if inspect.iscoroutinefunction(func):
+
+            @functools.wraps(func)
+            async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
+                started = time.perf_counter()
+                try:
+                    return await cast(Callable[..., Awaitable[Any]], func)(
+                        *args, **kwargs
+                    )
+                finally:
+                    target.observe(time.perf_counter() - started)
+
+            return cast(F, async_wrapper)
+
+        @functools.wraps(func)
+        def sync_wrapper(*args: Any, **kwargs: Any) -> Any:
+            started = time.perf_counter()
+            try:
+                return func(*args, **kwargs)
+            finally:
+                target.observe(time.perf_counter() - started)
+
+        return cast(F, sync_wrapper)
+
+    return decorator
+
+
+def track_feature_compute(feature: str) -> Callable[[F], F]:
+    """Time a feature computation into ``feature_compute_time``.
+
+    Args:
+        feature: Feature name used as the metric label.
+    """
+    return track_time(FEATURE_COMPUTE_TIME, feature)
+
+
+def track_inference(model: str) -> Callable[[F], F]:
+    """Time a model prediction into ``model_inference_latency``.
+
+    Args:
+        model: Model name used as the metric label.
+    """
+    return track_time(MODEL_INFERENCE_LATENCY, model)
+
+
+@contextmanager
+def track_active_job(job_type: str = "ingestion") -> Iterator[None]:
+    """Increment ``active_jobs`` for the duration of a job.
+
+    The gauge is decremented in a ``finally`` block, so a raising job does
+    not leak a permanently elevated count.
+
+    Args:
+        job_type: Label value, e.g. ``"ingestion"`` or ``"training"``.
+    """
+    gauge = ACTIVE_JOBS.labels(job_type)
+    gauge.inc()
+    try:
+        yield
+    finally:
+        gauge.dec()
+
+
+def render_latest(registry: CollectorRegistry = REGISTRY) -> tuple[bytes, str]:
+    """Render the Prometheus exposition payload.
+
+    Args:
+        registry: Registry to scrape. Defaults to the global registry.
+
+    Returns:
+        A ``(body, content_type)`` tuple ready to be returned from an
+        HTTP handler.
+    """
+    return generate_latest(registry), CONTENT_TYPE_LATEST

--- a/docs/HEALTH_CHECKS.md
+++ b/docs/HEALTH_CHECKS.md
@@ -1,0 +1,148 @@
+# Health Check Endpoints
+
+Granular health probes for the AstroML API (Issue #569), backed by the
+connection pool health checks from Issue #550.
+
+## Endpoints
+
+| Endpoint | Purpose | Fails (503) when |
+| --- | --- | --- |
+| `GET /healthz` | Aggregate status across all dependencies | Any component fails |
+| `GET /healthz/live` | Liveness — the process is responsive | Never (process is up) |
+| `GET /healthz/startup` | Startup probe — initialisation finished | Lifespan startup has not completed |
+| `GET /healthz/ready` | Readiness gate — safe to route traffic | Startup incomplete, DB unreachable, pool exhausted, disk full |
+| `GET /healthz/db` | Database connectivity + pool saturation | `SELECT 1` fails or the pool is exhausted |
+| `GET /healthz/cache` | Redis connectivity | Redis unreachable **and** `HEALTHZ_CACHE_REQUIRED=true` |
+| `GET /healthz/disk` | Free space on the data volume | Free space below 10% |
+| `GET /metrics/db-pool` | Connection pool utilization snapshot | Pool exhausted |
+
+The legacy `GET /health` and `GET /health/*` endpoints are unchanged; nothing
+that points at them needs to move.
+
+## Response envelope
+
+Every probe answers with the same JSON shape:
+
+```json
+{
+  "status": "ok",
+  "component": "db",
+  "details": { "latency_ms": 3.41, "query": "SELECT 1", "pool": { "...": "..." } },
+  "remediation": "",
+  "duration_ms": 3.52
+}
+```
+
+Aggregate probes (`/healthz`, `/healthz/ready`) nest one entry per component:
+
+```json
+{
+  "status": "degraded",
+  "probe": "ready",
+  "details": {
+    "startup": { "status": "ok", "component": "startup", "details": { "started": true, "ready": true, "uptime_seconds": 812.4 } },
+    "db":      { "status": "ok", "component": "db", "details": { "latency_ms": 2.9 } },
+    "cache":   { "status": "degraded", "component": "cache", "details": { "error": "Connection refused", "required": false } },
+    "disk":    { "status": "ok", "component": "disk", "details": { "free_ratio": 0.63 } }
+  },
+  "remediation": "Redis is unreachable. Verify REDIS_URL, that the Redis service is running, ..."
+}
+```
+
+### Status vocabulary
+
+| Status | HTTP | Meaning |
+| --- | ---: | --- |
+| `ok` | 200 | Fully functional |
+| `degraded` | 200 | Works, but close to a limit — keep serving, page someone |
+| `fail` | 503 | Unusable — Kubernetes should stop routing traffic here |
+
+`degraded` deliberately returns 200 so a saturated-but-working pod is not
+removed from the Service, which would concentrate load on the remaining pods.
+
+### Failure examples
+
+Database down:
+
+```json
+{
+  "status": "fail",
+  "component": "db",
+  "details": { "error": "connection refused", "error_type": "OSError" },
+  "remediation": "The database is unreachable. Verify DATABASE_URL, that the server accepts connections, and that credentials and network policy allow this pod to connect.",
+  "duration_ms": 5012.4
+}
+```
+
+Pool saturated (still 200, status `degraded`):
+
+```json
+{
+  "status": "degraded",
+  "pool": {
+    "pool_size": 20, "checked_in": 2, "checked_out": 25, "overflow": 5,
+    "max_overflow": 10, "capacity": 30, "utilization_percent": 83.33,
+    "alert_threshold_percent": 80.0, "saturated": true, "exhausted": false
+  },
+  "remediation": "Pool utilization is 83%, at or above the 80% alert threshold. Check for slow queries holding connections and consider raising DB_POOL_MAX_SIZE before it exhausts."
+}
+```
+
+## Readiness gating
+
+Readiness passes only when **startup has completed** and the **database** is
+reachable with a non-exhausted pool. The cache and disk checks can downgrade
+readiness to `degraded` but not fail it, unless disk space is critical or
+`HEALTHZ_CACHE_REQUIRED=true`.
+
+The API lifespan calls `readiness_state.mark_started()` after the scheduler and
+WebSocket poller are wired up, and `readiness_state.set_ready(False, ...)` at the
+start of shutdown — so a terminating pod reports `fail` on `/healthz/ready` and
+is drained from the Service before its dependencies are torn down.
+
+## Configuration
+
+| Variable | Default | Effect |
+| --- | --- | --- |
+| `HEALTHZ_TIMEOUT_SECONDS` | `5` | Per-dependency probe timeout |
+| `HEALTHZ_DISK_PATH` | `.` | Filesystem inspected by the disk probe |
+| `HEALTHZ_CACHE_REQUIRED` | `false` | When true, a Redis outage fails readiness |
+| `REDIS_URL` | `redis://localhost:6379/0` | Cache endpoint pinged by `/healthz/cache` |
+
+## Kubernetes probes
+
+`k8s/astroml-api-deployment.yaml` wires all three probe types:
+
+```yaml
+startupProbe:
+  httpGet: { path: /healthz/startup, port: 8000 }
+  periodSeconds: 5
+  failureThreshold: 30      # up to 150s to initialise
+livenessProbe:
+  httpGet: { path: /healthz/live, port: 8000 }
+  periodSeconds: 10
+  timeoutSeconds: 3
+  failureThreshold: 3
+readinessProbe:
+  httpGet: { path: /healthz/ready, port: 8000 }
+  periodSeconds: 5
+  timeoutSeconds: 5
+  failureThreshold: 3
+```
+
+Rules of thumb:
+
+- **Liveness must not check dependencies.** A database outage should not
+  restart every API pod — that turns a dependency outage into an outage plus a
+  restart storm.
+- **The startup probe owns slow boots.** With a startup probe configured,
+  Kubernetes suspends the liveness probe until startup succeeds, so
+  `initialDelaySeconds` tuning is no longer needed on liveness.
+- **Readiness is the traffic switch.** It is the only probe that should fail
+  when a dependency is down.
+
+## Related
+
+- Metric definitions: [METRICS_REFERENCE.md](METRICS_REFERENCE.md)
+- Pool internals: `astroml/db/pool_health.py`
+- Probe implementation: `api/routers/healthz.py`

--- a/docs/METRICS_REFERENCE.md
+++ b/docs/METRICS_REFERENCE.md
@@ -1,0 +1,138 @@
+# Prometheus Metrics Reference
+
+Metrics exported by the AstroML API and pipeline (Issues #567 and #550).
+Scrape endpoint: `GET /metrics` (Prometheus text exposition format).
+
+## Core metrics
+
+| Metric | Type | Labels | Meaning |
+| --- | --- | --- | --- |
+| `http_request_duration_seconds` | Histogram | `method`, `endpoint`, `status` | Request latency. `endpoint` is the **route template** (`/api/v1/accounts/{id}`), not the raw path, so cardinality stays bounded. |
+| `http_requests_total` | Counter | `method`, `endpoint`, `status` | Requests served, by response status. |
+| `db_pool_size` | Gauge | `pool`, `state` | Connections per state: `configured`, `in_use`, `idle`, `overflow`, `capacity`. |
+| `db_pool_utilization_ratio` | Gauge | `pool` | `in_use / capacity`, in `[0, 1]`. |
+| `feature_compute_time` | Histogram | `feature` | Seconds spent computing one feature. |
+| `model_inference_latency` | Histogram | `model` | Seconds spent in a model prediction call. |
+| `active_jobs` | Gauge | `job_type` | Jobs currently running, e.g. `ingestion`. |
+
+Histogram buckets: `0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30`
+seconds. Each histogram also exports the standard `_bucket`, `_sum` and
+`_count` series.
+
+## Instrumenting new code
+
+All helpers live in `astroml.observability.metrics` and work on sync *and*
+async callables.
+
+```python
+from astroml.observability.metrics import (
+    track_active_job,
+    track_feature_compute,
+    track_inference,
+    track_time,
+    FEATURE_COMPUTE_TIME,
+)
+
+@track_feature_compute("degree_centrality")
+def compute_degree_centrality(graph):
+    ...
+
+@track_inference("gnn_fraud_v2")
+async def predict(batch):
+    ...
+
+# Any histogram, any label set:
+@track_time(FEATURE_COMPUTE_TIME, "temporal_decay")
+def compute_temporal_decay(df):
+    ...
+
+# Gauge that stays balanced even if the job raises:
+with track_active_job("ingestion"):
+    run_backfill()
+```
+
+For a dynamic label value, use the Prometheus client directly:
+
+```python
+with FEATURE_COMPUTE_TIME.labels(feature_name).time():
+    result = compute(feature_name)
+```
+
+### Already instrumented
+
+| Path | Metric |
+| --- | --- |
+| API middleware (`api/app.py`) | `http_request_duration_seconds`, `http_requests_total` |
+| `FeatureEngine.compute_feature` | `feature_compute_time` |
+| `DeepSVDDFraudDetector.predict_anomaly_scores` | `model_inference_latency` |
+| `IngestionService.ingest_stream` | `active_jobs{job_type="ingestion"}` |
+| `/metrics`, `/healthz/db`, `/metrics/db-pool` | `db_pool_size`, `db_pool_utilization_ratio` |
+
+## Connection pool health indicators
+
+The pool gauges are sampled on every `/metrics` scrape and on every database
+health probe. Interpretation:
+
+| Indicator | Healthy | Investigate |
+| --- | --- | --- |
+| `db_pool_utilization_ratio` | < 0.8 | ≥ 0.8 sustained — leaked sessions or slow queries |
+| `db_pool_size{state="overflow"}` | 0 most of the time | Persistently > 0 — steady-state size is too small |
+| `db_pool_size{state="idle"}` | > 0 | Constantly 0 while `in_use` is high — pool is a bottleneck |
+
+Pool behaviour is configured through the same environment variables the API
+uses (`DB_POOL_MAX_SIZE`, `DB_POOL_MAX_OVERFLOW`, `DB_POOL_TIMEOUT`,
+`DB_POOL_RECYCLE`, `DB_POOL_PRE_PING`). Two settings matter for correctness
+rather than throughput:
+
+- **`pool_pre_ping=True`** (default) — every checkout is validated with a
+  cheap round trip, so a connection killed by a database restart or an
+  idle-timeout proxy surfaces as a retry rather than a request error.
+- **`pool_recycle=1800`** (default) — connections older than 30 minutes are
+  discarded, staying under typical proxy and `wait_timeout` limits.
+
+Useful queries:
+
+```promql
+# Pool utilization
+db_pool_utilization_ratio
+
+# Requests that would block once the pool saturates
+sum(rate(http_requests_total[5m])) by (endpoint)
+
+# P95 latency per endpoint
+histogram_quantile(0.95,
+  sum(rate(http_request_duration_seconds_bucket[5m])) by (le, endpoint))
+
+# Error ratio
+sum(rate(http_requests_total{status=~"5.."}[5m]))
+  / sum(rate(http_requests_total[5m]))
+```
+
+## Alerts
+
+Defined in `monitoring/prometheus/alert_rules.yml`, group `astroml_api_alerts`:
+
+| Alert | Condition | Severity |
+| --- | --- | --- |
+| `DatabasePoolNearExhaustion` | `db_pool_utilization_ratio >= 0.8` for 5m | warning |
+| `DatabasePoolExhausted` | `db_pool_utilization_ratio >= 1` for 1m | critical |
+| `ApiHighLatency` | P95 > 1s for 5m | warning |
+| `ApiHighErrorRate` | 5xx ratio > 5% for 5m | critical |
+| `IngestionJobsStalled` | `active_jobs{job_type="ingestion"} == 0` for 30m | warning |
+| `ModelInferenceLatencyHigh` | P95 > 2s for 10m | warning |
+
+## Grafana dashboards
+
+| Dashboard | File |
+| --- | --- |
+| API Health & Pool (these metrics) | [`monitoring/grafana/api_health_dashboard.json`](../monitoring/grafana/api_health_dashboard.json) |
+| API latency | [`monitoring/grafana/api_latency_dashboard.json`](../monitoring/grafana/api_latency_dashboard.json) |
+| Database performance | [`monitoring/grafana/database_performance_dashboard.json`](../monitoring/grafana/database_performance_dashboard.json) |
+| Ingestion throughput | [`monitoring/grafana/ingestion_throughput_dashboard.json`](../monitoring/grafana/ingestion_throughput_dashboard.json) |
+
+Dashboards are provisioned from `monitoring/grafana/provisioning/`.
+
+## Related
+
+- Health probes: [HEALTH_CHECKS.md](HEALTH_CHECKS.md)
+- Implementation: `astroml/observability/metrics.py`, `astroml/db/pool_health.py`

--- a/docs/PR_SIZE_LIMITS.md
+++ b/docs/PR_SIZE_LIMITS.md
@@ -1,0 +1,64 @@
+# Pull Request Size Limits
+
+AstroML enforces **soft** size limits on pull requests (Issue #557). Oversized
+PRs receive a warning comment from the `PR Size Limit` workflow. **CI is never
+failed because of size.**
+
+## Thresholds
+
+| Metric | Limit | Notes |
+| --- | ---: | --- |
+| Lines changed (additions + deletions) | 1000 | Counted from the GitHub PR event payload |
+| Files changed | 10 | Default ceiling |
+| Files changed (`refactor:large`) | 50 | Planned, mechanical refactors only |
+
+## Rationale
+
+Review quality degrades sharply as diff size grows:
+
+- Reviewers skim instead of reading, so defects reach `main`.
+- Time-to-first-review grows, which stalls the author.
+- Reverts get riskier, because unrelated changes are bundled into one commit.
+- Merge conflicts multiply while the PR waits.
+
+Small PRs are reviewed faster *and* more thoroughly, so the total time to land a
+feature is usually lower when it is split.
+
+## How to stay under the limits
+
+- **Stack the work.** Land the interface, then the implementation, then the
+  callers — each as its own PR.
+- **Separate refactors from behaviour changes.** A pure rename in one PR, the
+  logic change in the next.
+- **Use feature flags.** Merge incomplete work behind a disabled flag rather
+  than holding a long-lived branch open.
+- **Isolate generated content.** Lockfiles, migrations, vendored code, and
+  fixtures belong in their own PR.
+
+## Exceptions
+
+| Escape hatch | Effect |
+| --- | --- |
+| `refactor:large` label | Raises the file ceiling to 50 files |
+| `[large PR]` in the PR title | Skips the check entirely |
+
+Use `[large PR]` sparingly, and explain in the description why the change cannot
+be split.
+
+## Implementation
+
+- Policy logic: [`astroml/ci/pr_size.py`](../astroml/ci/pr_size.py) — fully typed
+  and unit tested in `tests/test_pr_size_limit.py`.
+- Workflow: [`.github/workflows/pr-size-limit.yml`](../.github/workflows/pr-size-limit.yml).
+
+The workflow runs on `pull_request_target` so it can comment on fork PRs. It
+checks out the **base** commit and never executes contributor code; it only
+reads the event payload.
+
+The bot maintains a single comment (identified by the
+`<!-- astroml:pr-size-limit -->` marker) and updates it in place — pushing more
+commits will not spam the thread, and shrinking the PR flips the comment to a
+pass state.
+
+To adjust the thresholds, change `SizeThresholds` defaults in
+`astroml/ci/pr_size.py` and update this document.

--- a/k8s/astroml-api-deployment.yaml
+++ b/k8s/astroml-api-deployment.yaml
@@ -45,17 +45,27 @@ spec:
           limits:
             memory: "512Mi"
             cpu: "500m"
+        # Granular probes (issue #569). The startup probe absorbs slow
+        # initialisation so the liveness probe never restarts a pod that is
+        # merely still booting; liveness checks only that the process is
+        # responsive; readiness gates traffic on dependency health.
+        startupProbe:
+          httpGet:
+            path: /healthz/startup
+            port: 8000
+          periodSeconds: 5
+          failureThreshold: 30
         livenessProbe:
           httpGet:
-            path: /health
+            path: /healthz/live
             port: 8000
-          initialDelaySeconds: 30
           periodSeconds: 10
+          timeoutSeconds: 3
           failureThreshold: 3
         readinessProbe:
           httpGet:
-            path: /api/v1/llm/health
+            path: /healthz/ready
             port: 8000
-          initialDelaySeconds: 15
           periodSeconds: 5
+          timeoutSeconds: 5
           failureThreshold: 3

--- a/monitoring/grafana/api_health_dashboard.json
+++ b/monitoring/grafana/api_health_dashboard.json
@@ -1,0 +1,125 @@
+{
+  "title": "AstroML API Health & Pool",
+  "uid": "astroml-api-health",
+  "tags": ["astroml", "api", "health", "database"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "time": { "from": "now-6h", "to": "now" },
+  "templating": {
+    "list": [
+      {
+        "name": "endpoint",
+        "type": "query",
+        "datasource": "Prometheus",
+        "query": "label_values(http_requests_total, endpoint)",
+        "includeAll": true,
+        "multi": true
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "timeseries",
+      "title": "HTTP request rate by status",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "targets": [
+        {
+          "expr": "sum(rate(http_requests_total{endpoint=~\"$endpoint\"}[5m])) by (status)",
+          "legendFormat": "{{status}}"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "type": "timeseries",
+      "title": "HTTP latency p50 / p95 / p99",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum(rate(http_request_duration_seconds_bucket{endpoint=~\"$endpoint\"}[5m])) by (le))",
+          "legendFormat": "p50"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket{endpoint=~\"$endpoint\"}[5m])) by (le))",
+          "legendFormat": "p95"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket{endpoint=~\"$endpoint\"}[5m])) by (le))",
+          "legendFormat": "p99"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "timeseries",
+      "title": "DB connection pool by state",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "targets": [
+        {
+          "expr": "db_pool_size",
+          "legendFormat": "{{pool}} — {{state}}"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "gauge",
+      "title": "DB pool utilization",
+      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 8 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 0.8 },
+              { "color": "red", "value": 0.95 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "targets": [{ "expr": "db_pool_utilization_ratio", "legendFormat": "{{pool}}" }]
+    },
+    {
+      "id": 5,
+      "type": "stat",
+      "title": "Active jobs",
+      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 8 },
+      "targets": [{ "expr": "active_jobs", "legendFormat": "{{job_type}}" }]
+    },
+    {
+      "id": 6,
+      "type": "timeseries",
+      "title": "Feature computation p95",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(feature_compute_time_bucket[10m])) by (le, feature))",
+          "legendFormat": "{{feature}}"
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "type": "timeseries",
+      "title": "Model inference latency p95",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(model_inference_latency_bucket[10m])) by (le, model))",
+          "legendFormat": "{{model}}"
+        }
+      ]
+    }
+  ]
+}

--- a/monitoring/prometheus/alert_rules.yml
+++ b/monitoring/prometheus/alert_rules.yml
@@ -74,3 +74,60 @@ groups:
         annotations:
           summary: "High LLM latency for {{ $labels.provider }}"
           description: "P95 latency for {{ $labels.provider }} is {{ $value }}s (threshold 5s)."
+
+  # ─── API health, latency and DB pool (issues #550, #567, #569) ────────────
+  - name: astroml_api_alerts
+    rules:
+      - alert: DatabasePoolNearExhaustion
+        expr: db_pool_utilization_ratio >= 0.8
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Database pool {{ $labels.pool }} above 80% utilization"
+          description: "Pool {{ $labels.pool }} has been at {{ $value | humanizePercentage }} of capacity for 5m. Check for leaked sessions or slow queries, then raise DB_POOL_MAX_SIZE."
+
+      - alert: DatabasePoolExhausted
+        expr: db_pool_utilization_ratio >= 1
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Database pool {{ $labels.pool }} exhausted"
+          description: "Every connection in pool {{ $labels.pool }} is checked out; new requests block until pool_timeout expires."
+
+      - alert: ApiHighLatency
+        expr: histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket[5m])) by (le, endpoint)) > 1
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "P95 latency above 1s for {{ $labels.endpoint }}"
+          description: "P95 request latency for {{ $labels.endpoint }} is {{ $value }}s over the last 5 minutes."
+
+      - alert: ApiHighErrorRate
+        expr: sum(rate(http_requests_total{status=~"5.."}[5m])) / sum(rate(http_requests_total[5m])) > 0.05
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "API 5xx rate above 5%"
+          description: "{{ $value | humanizePercentage }} of requests returned 5xx over the last 5 minutes."
+
+      - alert: IngestionJobsStalled
+        expr: active_jobs{job_type="ingestion"} == 0
+        for: 30m
+        labels:
+          severity: warning
+        annotations:
+          summary: "No active ingestion jobs for 30m"
+          description: "The active_jobs gauge for ingestion has been zero for 30 minutes; the backfill or stream worker may have died."
+
+      - alert: ModelInferenceLatencyHigh
+        expr: histogram_quantile(0.95, sum(rate(model_inference_latency_bucket[10m])) by (le, model)) > 2
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Model {{ $labels.model }} P95 inference latency above 2s"
+          description: "P95 inference latency for {{ $labels.model }} is {{ $value }}s over the last 10 minutes."

--- a/tests/test_db_pool_health.py
+++ b/tests/test_db_pool_health.py
@@ -1,0 +1,219 @@
+"""Tests for connection pool health inspection (Issue #550)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from sqlalchemy import create_engine
+
+from astroml.db.pool_health import (
+    POOL_UTILIZATION_ALERT_THRESHOLD,
+    PoolStats,
+    check_pool,
+    collect_pool_stats,
+    evaluate_pool_health,
+)
+from astroml.observability.health import HealthStatus
+
+
+class _FakePool:
+    """Minimal stand-in for ``QueuePool``."""
+
+    def __init__(
+        self,
+        size: int = 10,
+        checked_in: int = 5,
+        checked_out: int = 5,
+        overflow: int = -5,
+        max_overflow: int = 10,
+    ) -> None:
+        self._size = size
+        self._checked_in = checked_in
+        self._checked_out = checked_out
+        self._overflow = overflow
+        self._max_overflow = max_overflow
+
+    def size(self) -> int:
+        return self._size
+
+    def checkedin(self) -> int:
+        return self._checked_in
+
+    def checkedout(self) -> int:
+        return self._checked_out
+
+    def overflow(self) -> int:
+        return self._overflow
+
+
+class _FakeEngine:
+    def __init__(self, pool: Any) -> None:
+        self.pool = pool
+
+
+class _FakeAsyncEngine:
+    def __init__(self, pool: Any) -> None:
+        self.sync_engine = _FakeEngine(pool)
+
+
+def _stats(**overrides: Any) -> PoolStats:
+    values: dict[str, Any] = {
+        "pool_size": 10,
+        "checked_in": 8,
+        "checked_out": 2,
+        "overflow": 0,
+        "max_overflow": 10,
+        "implementation": "QueuePool",
+    }
+    values.update(overrides)
+    return PoolStats(**values)
+
+
+class TestPoolStats:
+    def test_capacity_is_size_plus_overflow(self) -> None:
+        assert _stats().capacity == 20
+
+    def test_utilization_ratio(self) -> None:
+        assert _stats(checked_out=5).utilization == pytest.approx(0.25)
+
+    def test_utilization_is_zero_for_empty_capacity(self) -> None:
+        assert _stats(pool_size=0, max_overflow=0).utilization == 0.0
+
+    def test_utilization_is_capped_at_one(self) -> None:
+        assert _stats(checked_out=999).utilization == 1.0
+
+    def test_saturation_threshold(self) -> None:
+        assert _stats(checked_out=16).saturated is True
+        assert _stats(checked_out=16).utilization == pytest.approx(
+            POOL_UTILIZATION_ALERT_THRESHOLD
+        )
+        assert _stats(checked_out=15).saturated is False
+
+    def test_exhaustion(self) -> None:
+        assert _stats(checked_out=20).exhausted is True
+        assert _stats(checked_out=19).exhausted is False
+
+    def test_to_dict_exposes_operator_fields(self) -> None:
+        body = _stats(checked_out=16).to_dict()
+
+        assert body["utilization_percent"] == 80.0
+        assert body["alert_threshold_percent"] == 80.0
+        assert body["saturated"] is True
+        assert body["exhausted"] is False
+        assert body["implementation"] == "QueuePool"
+
+
+class TestCollectPoolStats:
+    def test_reads_counters_from_engine(self) -> None:
+        stats = collect_pool_stats(_FakeEngine(_FakePool()))
+
+        assert stats.pool_size == 10
+        assert stats.checked_in == 5
+        assert stats.checked_out == 5
+        assert stats.max_overflow == 10
+        assert stats.implementation == "_FakePool"
+
+    def test_negative_overflow_is_clamped(self) -> None:
+        assert collect_pool_stats(_FakeEngine(_FakePool(overflow=-5))).overflow == 0
+
+    def test_async_engine_is_unwrapped(self) -> None:
+        stats = collect_pool_stats(_FakeAsyncEngine(_FakePool(size=7)))
+        assert stats.pool_size == 7
+
+    def test_pool_without_counters_reports_zeros(self) -> None:
+        class _Bare:
+            pass
+
+        stats = collect_pool_stats(_FakeEngine(_Bare()))
+
+        assert stats.pool_size == 0
+        assert stats.capacity == 0
+        assert stats.utilization == 0.0
+
+    def test_raising_counter_is_tolerated(self) -> None:
+        class _Raising(_FakePool):
+            def checkedout(self) -> int:
+                raise RuntimeError("pool detached")
+
+        assert collect_pool_stats(_FakeEngine(_Raising())).checked_out == 0
+
+    def test_non_numeric_counter_is_tolerated(self) -> None:
+        class _Weird(_FakePool):
+            def size(self) -> Any:
+                return "not-a-number"
+
+        assert collect_pool_stats(_FakeEngine(_Weird())).pool_size == 0
+
+    def test_real_sqlite_engine(self) -> None:
+        engine = create_engine("sqlite://")
+        stats = collect_pool_stats(engine)
+
+        assert stats.checked_out >= 0
+        assert stats.implementation
+
+
+class TestEvaluatePoolHealth:
+    def test_healthy_pool(self) -> None:
+        result = evaluate_pool_health(_stats(checked_out=2))
+
+        assert result.status is HealthStatus.OK
+        assert result.remediation == ""
+        assert result.name == "db_pool"
+
+    def test_saturated_pool_is_degraded(self) -> None:
+        result = evaluate_pool_health(_stats(checked_out=17))
+
+        assert result.status is HealthStatus.DEGRADED
+        assert result.http_status == 200
+        assert "alert" in result.remediation
+        assert "DB_POOL_MAX_SIZE" in result.remediation
+
+    def test_exhausted_pool_fails(self) -> None:
+        result = evaluate_pool_health(_stats(checked_out=20))
+
+        assert result.status is HealthStatus.FAIL
+        assert result.http_status == 503
+        assert "pool_timeout" in result.remediation
+
+    def test_zero_capacity_pool_is_ok(self) -> None:
+        result = evaluate_pool_health(
+            _stats(pool_size=0, max_overflow=0, checked_out=0)
+        )
+        assert result.status is HealthStatus.OK
+
+
+class TestCheckPool:
+    def test_check_pool_sets_duration(self) -> None:
+        result = check_pool(_FakeEngine(_FakePool()))
+
+        assert result.name == "db_pool"
+        assert result.duration_ms >= 0.0
+        assert result.details["pool_size"] == 10
+
+    def test_check_pool_flags_saturation(self) -> None:
+        result = check_pool(_FakeEngine(_FakePool(checked_out=20, max_overflow=10)))
+        assert result.status is HealthStatus.FAIL
+
+
+class TestSessionHelpers:
+    def test_session_module_exposes_pool_helpers(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from astroml.db import session as session_module
+
+        engine = _FakeEngine(_FakePool(checked_out=1))
+        monkeypatch.setattr(session_module, "get_engine", lambda: engine)
+
+        assert session_module.get_pool_stats().checked_out == 1
+        assert session_module.check_connection_pool().status is HealthStatus.OK
+
+    def test_engine_enables_pre_ping_and_recycling(self) -> None:
+        import inspect
+
+        from astroml.db import session as session_module
+
+        source = inspect.getsource(session_module.get_engine)
+
+        assert "pool_pre_ping=True" in source
+        assert "pool_recycle" in source

--- a/tests/test_healthz_endpoints.py
+++ b/tests/test_healthz_endpoints.py
@@ -1,0 +1,428 @@
+"""HTTP-level tests for the /healthz probes and /metrics/db-pool (#569, #550).
+
+The router is mounted on a bare FastAPI app so these tests exercise the probe
+contract without importing the full application graph (auth middleware,
+GraphQL schema, scheduler).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Iterator
+
+import pytest
+
+fastapi = pytest.importorskip("fastapi")
+pytest.importorskip("httpx")
+
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+from astroml.db.pool_health import PoolStats  # noqa: E402
+from astroml.observability.health import (  # noqa: E402
+    CheckResult,
+    HealthStatus,
+    readiness_state,
+)
+
+
+@pytest.fixture(scope="module")
+def healthz_module() -> Any:
+    """Load ``api/routers/healthz.py`` in isolation.
+
+    Importing it as ``api.routers.healthz`` would execute
+    ``api/routers/__init__.py``, which eagerly imports every router in the
+    service (auth, GraphQL, LLM providers, …) along with dependencies the
+    CPU CI image does not install. The probe module only needs FastAPI,
+    SQLAlchemy and ``api.database``, so it is loaded directly from its path.
+    """
+    import importlib.util
+    from pathlib import Path
+
+    path = Path(__file__).resolve().parents[1] / "api" / "routers" / "healthz.py"
+    spec = importlib.util.spec_from_file_location("astroml_healthz_probe", path)
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive
+        pytest.skip(f"Cannot load health router from {path}")
+
+    module = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(module)
+    except ImportError as exc:  # pragma: no cover - environment dependent
+        pytest.skip(f"API dependencies unavailable: {exc}")
+
+    return module
+
+
+@pytest.fixture()
+def client(healthz_module: Any) -> Iterator[TestClient]:
+    app = FastAPI()
+    app.include_router(healthz_module.router)
+    with TestClient(app) as test_client:
+        yield test_client
+
+
+@pytest.fixture(autouse=True)
+def _ready_process() -> Iterator[None]:
+    readiness_state.mark_started()
+    yield
+    readiness_state.reset()
+
+
+@pytest.fixture()
+def healthy_pool(healthz_module: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        healthz_module,
+        "_pool_check",
+        lambda: CheckResult(
+            name="db_pool",
+            status=HealthStatus.OK,
+            details=PoolStats(10, 8, 2, 0, 10, "QueuePool").to_dict(),
+        ),
+    )
+
+
+def _ok_db() -> Any:
+    async def _check() -> CheckResult:
+        return CheckResult(
+            name="db", status=HealthStatus.OK, details={"latency_ms": 1.0}
+        )
+
+    return _check
+
+
+def _failing(name: str, remediation: str = "Fix it.") -> Any:
+    async def _check() -> CheckResult:
+        return CheckResult(
+            name=name,
+            status=HealthStatus.FAIL,
+            details={"error": "boom"},
+            remediation=remediation,
+        )
+
+    return _check
+
+
+def _degraded(name: str) -> Any:
+    async def _check() -> CheckResult:
+        return CheckResult(
+            name=name, status=HealthStatus.DEGRADED, remediation="Watch it."
+        )
+
+    return _check
+
+
+@pytest.fixture()
+def all_healthy(healthz_module: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(healthz_module, "check_database", _ok_db())
+    monkeypatch.setattr(
+        healthz_module,
+        "check_cache",
+        lambda: _resolved(CheckResult("cache", HealthStatus.OK)),
+    )
+    monkeypatch.setattr(
+        healthz_module,
+        "check_disk_space",
+        lambda: _resolved(CheckResult("disk", HealthStatus.OK)),
+    )
+
+
+async def _resolved(result: CheckResult) -> CheckResult:
+    return result
+
+
+class TestLiveness:
+    def test_live_is_always_ok(self, client: TestClient) -> None:
+        response = client.get("/healthz/live")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["status"] == "ok"
+        assert body["component"] == "live"
+        assert "uptime_seconds" in body["details"]
+
+    def test_live_ignores_dependency_failures(
+        self, client: TestClient, healthz_module: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(healthz_module, "check_database", _failing("db"))
+
+        assert client.get("/healthz/live").status_code == 200
+
+
+class TestStartupProbe:
+    def test_startup_ok_after_mark_started(self, client: TestClient) -> None:
+        response = client.get("/healthz/startup")
+
+        assert response.status_code == 200
+        assert response.json()["details"]["started"] is True
+
+    def test_startup_fails_before_initialisation(self, client: TestClient) -> None:
+        readiness_state.reset()
+
+        response = client.get("/healthz/startup")
+
+        assert response.status_code == 503
+        assert response.json()["status"] == "fail"
+        assert "initialising" in response.json()["remediation"]
+
+
+class TestReadiness:
+    def test_ready_when_dependencies_pass(
+        self, client: TestClient, all_healthy: None
+    ) -> None:
+        response = client.get("/healthz/ready")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["status"] == "ok"
+        assert body["probe"] == "ready"
+        assert set(body["details"]) == {"startup", "db", "cache", "disk"}
+
+    def test_not_ready_before_startup(self, client: TestClient) -> None:
+        readiness_state.reset()
+
+        response = client.get("/healthz/ready")
+
+        assert response.status_code == 503
+        assert set(response.json()["details"]) == {"startup"}
+
+    def test_database_failure_blocks_readiness(
+        self,
+        client: TestClient,
+        all_healthy: None,
+        healthz_module: Any,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(
+            healthz_module, "check_database", _failing("db", "Check DATABASE_URL.")
+        )
+
+        response = client.get("/healthz/ready")
+
+        assert response.status_code == 503
+        assert response.json()["status"] == "fail"
+        assert "Check DATABASE_URL." in response.json()["remediation"]
+
+    def test_cache_degradation_still_serves_traffic(
+        self,
+        client: TestClient,
+        all_healthy: None,
+        healthz_module: Any,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(healthz_module, "check_cache", _degraded("cache"))
+
+        response = client.get("/healthz/ready")
+
+        assert response.status_code == 200
+        assert response.json()["status"] == "degraded"
+
+    def test_draining_pod_is_not_ready(
+        self, client: TestClient, all_healthy: None
+    ) -> None:
+        readiness_state.set_ready(False, "Application is shutting down.")
+
+        response = client.get("/healthz/ready")
+
+        assert response.status_code == 503
+        assert "shutting down" in response.json()["remediation"]
+
+
+class TestAggregateHealthz:
+    def test_aggregate_reports_every_component(
+        self, client: TestClient, all_healthy: None
+    ) -> None:
+        response = client.get("/healthz")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["probe"] == "healthz"
+        assert set(body["details"]) == {"startup", "db", "cache", "disk"}
+
+    def test_aggregate_surfaces_worst_status(
+        self,
+        client: TestClient,
+        all_healthy: None,
+        healthz_module: Any,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(healthz_module, "check_disk_space", _failing("disk"))
+
+        response = client.get("/healthz")
+
+        assert response.status_code == 503
+        assert response.json()["status"] == "fail"
+
+
+class TestComponentProbes:
+    def test_db_probe(
+        self, client: TestClient, healthz_module: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(healthz_module, "check_database", _ok_db())
+
+        response = client.get("/healthz/db")
+
+        assert response.status_code == 200
+        assert response.json()["component"] == "db"
+
+    def test_db_probe_failure_returns_503(
+        self, client: TestClient, healthz_module: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            healthz_module, "check_database", _failing("db", "Verify DATABASE_URL.")
+        )
+
+        response = client.get("/healthz/db")
+
+        assert response.status_code == 503
+        assert "Verify DATABASE_URL." in response.json()["remediation"]
+
+    def test_cache_probe(
+        self, client: TestClient, healthz_module: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            healthz_module,
+            "check_cache",
+            lambda: _resolved(
+                CheckResult("cache", HealthStatus.OK, {"latency_ms": 0.5})
+            ),
+        )
+
+        response = client.get("/healthz/cache")
+
+        assert response.status_code == 200
+        assert response.json()["details"]["latency_ms"] == 0.5
+
+    def test_cache_outage_is_degraded_by_default(
+        self, client: TestClient, healthz_module: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(healthz_module, "check_cache", _degraded("cache"))
+
+        response = client.get("/healthz/cache")
+
+        assert response.status_code == 200
+        assert response.json()["status"] == "degraded"
+
+    def test_disk_probe(self, client: TestClient) -> None:
+        response = client.get("/healthz/disk")
+
+        assert response.status_code in (200, 503)
+        assert response.json()["component"] == "disk"
+        assert "free_bytes" in response.json()["details"]
+
+
+class TestProbeResilience:
+    def test_timeout_is_reported_as_failure(
+        self, client: TestClient, healthz_module: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        async def _hang() -> CheckResult:
+            await asyncio.sleep(10)
+            raise AssertionError("unreachable")
+
+        monkeypatch.setattr(healthz_module, "CHECK_TIMEOUT_SECONDS", 0.01)
+        monkeypatch.setattr(healthz_module, "check_database", _hang)
+
+        response = client.get("/healthz/db")
+
+        assert response.status_code == 503
+        assert "timed out" in response.json()["details"]["error"]
+
+    def test_unexpected_exception_is_reported_as_failure(
+        self, client: TestClient, healthz_module: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        async def _boom() -> CheckResult:
+            raise RuntimeError("driver exploded")
+
+        monkeypatch.setattr(healthz_module, "check_database", _boom)
+
+        response = client.get("/healthz/db")
+
+        assert response.status_code == 503
+        body = response.json()
+        assert body["details"]["error_type"] == "RuntimeError"
+        assert "driver exploded" in body["remediation"]
+
+
+class TestDbPoolMetricsEndpoint:
+    def test_pool_snapshot_is_served(
+        self, client: TestClient, healthy_pool: None
+    ) -> None:
+        response = client.get("/metrics/db-pool")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["status"] == "ok"
+        assert body["pool"]["pool_size"] == 10
+        assert body["pool"]["alert_threshold_percent"] == 80.0
+
+    def test_saturated_pool_is_degraded(
+        self, client: TestClient, healthz_module: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from astroml.db.pool_health import evaluate_pool_health
+
+        stats = PoolStats(10, 2, 17, 7, 10, "QueuePool")
+        monkeypatch.setattr(
+            healthz_module, "_pool_check", lambda: evaluate_pool_health(stats)
+        )
+
+        response = client.get("/metrics/db-pool")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["status"] == "degraded"
+        assert body["pool"]["saturated"] is True
+        assert "DB_POOL_MAX_SIZE" in body["remediation"]
+
+    def test_exhausted_pool_returns_503(
+        self, client: TestClient, healthz_module: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from astroml.db.pool_health import evaluate_pool_health
+
+        stats = PoolStats(10, 0, 20, 10, 10, "QueuePool")
+        monkeypatch.setattr(
+            healthz_module, "_pool_check", lambda: evaluate_pool_health(stats)
+        )
+
+        response = client.get("/metrics/db-pool")
+
+        assert response.status_code == 503
+        assert response.json()["pool"]["exhausted"] is True
+
+
+class TestDatabaseCheckImplementation:
+    def test_connection_error_is_reported(
+        self, healthz_module: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def _factory() -> Any:
+            raise OSError("connection refused")
+
+        monkeypatch.setattr(healthz_module, "get_async_session_factory", _factory)
+
+        result = asyncio.run(healthz_module.check_database())
+
+        assert result.status is HealthStatus.FAIL
+        assert result.details["error_type"] == "OSError"
+        assert "DATABASE_URL" in result.remediation
+
+    def test_cache_ping_failure_degrades(
+        self, healthz_module: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def _boom(_url: str) -> float:
+            raise ConnectionError("no route to host")
+
+        monkeypatch.setattr(healthz_module, "_ping_redis", _boom)
+        monkeypatch.setattr(healthz_module, "CACHE_REQUIRED", False)
+
+        result = asyncio.run(healthz_module.check_cache())
+
+        assert result.status is HealthStatus.DEGRADED
+        assert "REDIS_URL" in result.remediation
+
+    def test_cache_ping_success(
+        self, healthz_module: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(healthz_module, "_ping_redis", lambda _url: 1.5)
+
+        result = asyncio.run(healthz_module.check_cache())
+
+        assert result.status is HealthStatus.OK
+        assert result.details["latency_ms"] == 1.5

--- a/tests/test_healthz_endpoints.py
+++ b/tests/test_healthz_endpoints.py
@@ -130,6 +130,23 @@ async def _resolved(result: CheckResult) -> CheckResult:
     return result
 
 
+class _FakeSession:
+    """Minimal async session that answers ``SELECT 1``."""
+
+    async def execute(self, _statement: Any) -> None:
+        return None
+
+    async def __aenter__(self) -> "_FakeSession":
+        return self
+
+    async def __aexit__(self, *_exc: Any) -> None:
+        return None
+
+
+def _FakeSessionFactory() -> _FakeSession:  # noqa: N802 - mimics a factory call
+    return _FakeSession()
+
+
 class TestLiveness:
     def test_live_is_always_ok(self, client: TestClient) -> None:
         response = client.get("/healthz/live")
@@ -426,3 +443,100 @@ class TestDatabaseCheckImplementation:
 
         assert result.status is HealthStatus.OK
         assert result.details["latency_ms"] == 1.5
+
+    def test_cache_required_turns_outage_into_failure(
+        self, healthz_module: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def _boom(_url: str) -> float:
+            raise ConnectionError("refused")
+
+        monkeypatch.setattr(healthz_module, "_ping_redis", _boom)
+        monkeypatch.setattr(healthz_module, "CACHE_REQUIRED", True)
+
+        result = asyncio.run(healthz_module.check_cache())
+
+        assert result.status is HealthStatus.FAIL
+        assert result.details["required"] is True
+
+    def test_successful_query_folds_in_pool_status(
+        self, healthz_module: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            healthz_module, "get_async_session_factory", lambda: _FakeSessionFactory
+        )
+        monkeypatch.setattr(
+            healthz_module,
+            "_pool_check",
+            lambda: CheckResult(
+                name="db_pool",
+                status=HealthStatus.DEGRADED,
+                details=PoolStats(10, 2, 17, 7, 10, "QueuePool").to_dict(),
+                remediation="Raise DB_POOL_MAX_SIZE.",
+            ),
+        )
+
+        result = asyncio.run(healthz_module.check_database())
+
+        assert result.status is HealthStatus.DEGRADED
+        assert result.details["query"] == "SELECT 1"
+        assert result.details["pool"]["saturated"] is True
+        assert result.remediation == "Raise DB_POOL_MAX_SIZE."
+
+    def test_pool_check_publishes_prometheus_gauges(
+        self, healthz_module: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from prometheus_client import REGISTRY
+
+        class _Pool:
+            def size(self) -> int:
+                return 4
+
+            def checkedin(self) -> int:
+                return 3
+
+            def checkedout(self) -> int:
+                return 1
+
+            def overflow(self) -> int:
+                return -4
+
+        class _Engine:
+            pool = _Pool()
+
+        monkeypatch.setattr(healthz_module, "get_async_engine", lambda: _Engine())
+
+        result = healthz_module._pool_check()
+
+        assert result.status is HealthStatus.OK
+        assert (
+            REGISTRY.get_sample_value(
+                "db_pool_size", {"pool": "default", "state": "in_use"}
+            )
+            == 1
+        )
+
+    def test_ping_redis_uses_client_and_closes_it(
+        self, healthz_module: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import sys
+        import types
+
+        closed: list[bool] = []
+
+        class _Client:
+            def ping(self) -> bool:
+                return True
+
+            def close(self) -> None:
+                closed.append(True)
+
+        fake_redis = types.ModuleType("redis")
+        fake_redis.Redis = types.SimpleNamespace(  # type: ignore[attr-defined]
+            from_url=lambda url, **kwargs: _Client()
+        )
+        monkeypatch.setitem(sys.modules, "redis", fake_redis)
+
+        latency_ms = healthz_module._ping_redis("redis://localhost:6379/0")
+
+        assert latency_ms >= 0.0
+        assert closed == [True]

--- a/tests/test_observability_health.py
+++ b/tests/test_observability_health.py
@@ -1,0 +1,218 @@
+"""Tests for health check primitives (Issue #569)."""
+
+from __future__ import annotations
+
+import shutil
+from typing import Any
+
+import pytest
+
+from astroml.observability.health import (
+    HTTP_STATUS_FOR,
+    CheckResult,
+    HealthStatus,
+    ReadinessState,
+    aggregate_status,
+    aggregate_to_dict,
+    check_disk,
+)
+
+
+class _Usage:
+    """Stand-in for ``shutil.disk_usage`` results."""
+
+    def __init__(self, total: int, free: int) -> None:
+        self.total = total
+        self.free = free
+        self.used = total - free
+
+
+class TestHealthStatus:
+    @pytest.mark.parametrize(
+        ("status", "serving"),
+        [
+            (HealthStatus.OK, True),
+            (HealthStatus.DEGRADED, True),
+            (HealthStatus.FAIL, False),
+        ],
+    )
+    def test_is_serving(self, status: HealthStatus, serving: bool) -> None:
+        assert status.is_serving is serving
+
+    @pytest.mark.parametrize(
+        ("status", "code"),
+        [
+            (HealthStatus.OK, 200),
+            (HealthStatus.DEGRADED, 200),
+            (HealthStatus.FAIL, 503),
+        ],
+    )
+    def test_http_status_mapping(self, status: HealthStatus, code: int) -> None:
+        assert HTTP_STATUS_FOR[status] == code
+
+
+class TestCheckResult:
+    def test_to_dict_shape(self) -> None:
+        result = CheckResult(
+            name="db",
+            status=HealthStatus.DEGRADED,
+            details={"latency_ms": 12.0},
+            remediation="Scale the pool.",
+            duration_ms=12.3456,
+        )
+
+        assert result.to_dict() == {
+            "status": "degraded",
+            "component": "db",
+            "details": {"latency_ms": 12.0},
+            "remediation": "Scale the pool.",
+            "duration_ms": 12.35,
+        }
+
+    def test_http_status_for_failure(self) -> None:
+        assert CheckResult("db", HealthStatus.FAIL).http_status == 503
+
+    def test_defaults(self) -> None:
+        result = CheckResult("live", HealthStatus.OK)
+        assert result.details == {}
+        assert result.remediation == ""
+
+
+class TestAggregation:
+    def test_empty_is_ok(self) -> None:
+        assert aggregate_status([]) is HealthStatus.OK
+
+    def test_worst_status_wins(self) -> None:
+        results = [
+            CheckResult("a", HealthStatus.OK),
+            CheckResult("b", HealthStatus.DEGRADED),
+            CheckResult("c", HealthStatus.FAIL),
+        ]
+        assert aggregate_status(results) is HealthStatus.FAIL
+
+    def test_degraded_beats_ok(self) -> None:
+        results = [
+            CheckResult("a", HealthStatus.OK),
+            CheckResult("b", HealthStatus.DEGRADED),
+        ]
+        assert aggregate_status(results) is HealthStatus.DEGRADED
+
+    def test_aggregate_to_dict_merges_remediation(self) -> None:
+        body = aggregate_to_dict(
+            [
+                CheckResult("a", HealthStatus.OK),
+                CheckResult("b", HealthStatus.FAIL, remediation="Restart b."),
+            ],
+            remediation_prefix="Service is not ready.",
+        )
+
+        assert body["status"] == "fail"
+        assert set(body["details"]) == {"a", "b"}
+        assert body["remediation"] == "Service is not ready. Restart b."
+
+
+class TestCheckDisk:
+    def test_healthy_disk(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(shutil, "disk_usage", lambda _p: _Usage(100, 60))
+
+        result = check_disk("/data")
+
+        assert result.status is HealthStatus.OK
+        assert result.remediation == ""
+        assert result.details["free_ratio"] == 0.6
+        assert result.details["path"] == "/data"
+
+    def test_degraded_disk(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(shutil, "disk_usage", lambda _p: _Usage(100, 15))
+
+        result = check_disk("/data")
+
+        assert result.status is HealthStatus.DEGRADED
+        assert "Schedule cleanup" in result.remediation
+
+    def test_failing_disk(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(shutil, "disk_usage", lambda _p: _Usage(100, 5))
+
+        result = check_disk("/data")
+
+        assert result.status is HealthStatus.FAIL
+        assert result.http_status == 503
+        assert "Free space immediately" in result.remediation
+
+    def test_custom_thresholds(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(shutil, "disk_usage", lambda _p: _Usage(100, 50))
+
+        result = check_disk("/data", degraded_ratio=0.9, fail_ratio=0.6)
+
+        assert result.status is HealthStatus.FAIL
+
+    def test_zero_capacity_is_failure(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(shutil, "disk_usage", lambda _p: _Usage(0, 0))
+
+        assert check_disk("/data").status is HealthStatus.FAIL
+
+    def test_oserror_is_reported_not_raised(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def _boom(_path: Any) -> Any:
+            raise OSError("not mounted")
+
+        monkeypatch.setattr(shutil, "disk_usage", _boom)
+
+        result = check_disk("/data")
+
+        assert result.status is HealthStatus.FAIL
+        assert result.details["error"] == "not mounted"
+        assert "volume is mounted" in result.remediation
+
+
+class TestReadinessState:
+    def test_starts_not_ready(self) -> None:
+        state = ReadinessState()
+
+        assert state.started is False
+        assert state.ready is False
+        assert state.uptime_seconds == 0.0
+
+        snapshot = state.snapshot()
+        assert snapshot.status is HealthStatus.FAIL
+        assert snapshot.details == {"started": False, "ready": False}
+        assert "still initialising" in snapshot.remediation
+
+    def test_ready_after_startup(self) -> None:
+        state = ReadinessState()
+        state.mark_started()
+
+        assert state.started is True
+        assert state.ready is True
+        assert state.uptime_seconds >= 0.0
+        assert state.snapshot().status is HealthStatus.OK
+
+    def test_draining_revokes_readiness_but_keeps_started(self) -> None:
+        state = ReadinessState()
+        state.mark_started()
+        state.set_ready(False, "Application is shutting down.")
+
+        assert state.started is True
+        assert state.ready is False
+
+        snapshot = state.snapshot()
+        assert snapshot.status is HealthStatus.FAIL
+        assert "shutting down" in snapshot.remediation
+        assert snapshot.details["started"] is True
+
+    def test_set_ready_true_restores_default_detail(self) -> None:
+        state = ReadinessState()
+        state.mark_started()
+        state.set_ready(False)
+        state.set_ready(True)
+
+        assert state.ready is True
+
+    def test_reset_returns_to_initial_state(self) -> None:
+        state = ReadinessState()
+        state.mark_started()
+        state.reset()
+
+        assert state.started is False
+        assert state.ready is False

--- a/tests/test_observability_metrics.py
+++ b/tests/test_observability_metrics.py
@@ -1,0 +1,235 @@
+"""Tests for Prometheus metric coverage and instrumentation (Issue #567)."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from prometheus_client import REGISTRY
+
+from astroml.observability.metrics import (
+    ACTIVE_JOBS,
+    DB_POOL_SIZE,
+    DB_POOL_UTILIZATION,
+    FEATURE_COMPUTE_TIME,
+    HTTP_REQUEST_DURATION,
+    HTTP_REQUESTS_TOTAL,
+    MODEL_INFERENCE_LATENCY,
+    observe_http_request,
+    render_latest,
+    track_active_job,
+    track_feature_compute,
+    track_inference,
+    track_time,
+    update_db_pool_metrics,
+)
+from astroml.db.pool_health import PoolStats
+
+
+def _sample(name: str, **labels: str) -> float:
+    value = REGISTRY.get_sample_value(name, labels)
+    return 0.0 if value is None else value
+
+
+class TestMetricRegistration:
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "http_request_duration_seconds",
+            "http_requests_total",
+            "db_pool_size",
+            "db_pool_utilization_ratio",
+            "feature_compute_time",
+            "model_inference_latency",
+            "active_jobs",
+        ],
+    )
+    def test_metric_is_registered(self, name: str) -> None:
+        assert name in REGISTRY._names_to_collectors
+
+    def test_labels_are_declared(self) -> None:
+        assert HTTP_REQUEST_DURATION._labelnames == ("method", "endpoint", "status")
+        assert HTTP_REQUESTS_TOTAL._labelnames == ("method", "endpoint", "status")
+        assert DB_POOL_SIZE._labelnames == ("pool", "state")
+        assert DB_POOL_UTILIZATION._labelnames == ("pool",)
+        assert FEATURE_COMPUTE_TIME._labelnames == ("feature",)
+        assert MODEL_INFERENCE_LATENCY._labelnames == ("model",)
+        assert ACTIVE_JOBS._labelnames == ("job_type",)
+
+
+class TestHttpMetrics:
+    def test_request_is_counted_and_timed(self) -> None:
+        labels = {"method": "GET", "endpoint": "/healthz", "status": "200"}
+        before = _sample("http_requests_total", **labels)
+
+        observe_http_request("get", "/healthz", 200, 0.05)
+
+        assert _sample("http_requests_total", **labels) == before + 1
+        assert _sample("http_request_duration_seconds_count", **labels) >= 1
+        assert _sample("http_request_duration_seconds_sum", **labels) >= 0.05
+
+    def test_status_codes_are_separate_series(self) -> None:
+        observe_http_request("GET", "/healthz/db", 503, 0.01)
+
+        assert (
+            _sample(
+                "http_requests_total",
+                method="GET",
+                endpoint="/healthz/db",
+                status="503",
+            )
+            >= 1
+        )
+
+
+class TestDbPoolMetrics:
+    def test_pool_stats_are_published(self) -> None:
+        stats = PoolStats(
+            pool_size=10,
+            checked_in=3,
+            checked_out=8,
+            overflow=1,
+            max_overflow=10,
+            implementation="QueuePool",
+        )
+
+        update_db_pool_metrics(stats, pool_name="test-pool")
+
+        assert _sample("db_pool_size", pool="test-pool", state="configured") == 10
+        assert _sample("db_pool_size", pool="test-pool", state="in_use") == 8
+        assert _sample("db_pool_size", pool="test-pool", state="idle") == 3
+        assert _sample("db_pool_size", pool="test-pool", state="overflow") == 1
+        assert _sample("db_pool_size", pool="test-pool", state="capacity") == 20
+        assert _sample("db_pool_utilization_ratio", pool="test-pool") == pytest.approx(
+            0.4
+        )
+
+
+class TestTrackTime:
+    def test_sync_function_is_timed(self) -> None:
+        @track_time(FEATURE_COMPUTE_TIME, "sync_feature")
+        def compute() -> int:
+            return 42
+
+        assert compute() == 42
+        assert _sample("feature_compute_time_count", feature="sync_feature") == 1
+
+    def test_async_function_is_timed(self) -> None:
+        @track_time(MODEL_INFERENCE_LATENCY, "async_model")
+        async def infer() -> str:
+            await asyncio.sleep(0)
+            return "done"
+
+        assert asyncio.run(infer()) == "done"
+        assert _sample("model_inference_latency_count", model="async_model") == 1
+
+    def test_exception_is_still_timed_and_propagates(self) -> None:
+        @track_time(FEATURE_COMPUTE_TIME, "boom")
+        def compute() -> None:
+            raise ValueError("nope")
+
+        with pytest.raises(ValueError, match="nope"):
+            compute()
+
+        assert _sample("feature_compute_time_count", feature="boom") == 1
+
+    def test_async_exception_is_still_timed(self) -> None:
+        @track_time(MODEL_INFERENCE_LATENCY, "async_boom")
+        async def infer() -> None:
+            raise RuntimeError("bad")
+
+        with pytest.raises(RuntimeError, match="bad"):
+            asyncio.run(infer())
+
+        assert _sample("model_inference_latency_count", model="async_boom") == 1
+
+    def test_metadata_is_preserved(self) -> None:
+        @track_time(FEATURE_COMPUTE_TIME, "documented")
+        def compute() -> None:
+            """Docstring."""
+
+        assert compute.__name__ == "compute"
+        assert compute.__doc__ == "Docstring."
+
+    def test_unlabelled_histogram_is_supported(self) -> None:
+        from prometheus_client import CollectorRegistry, Histogram
+
+        registry = CollectorRegistry()
+        histogram = Histogram("bare_seconds", "doc", registry=registry)
+
+        @track_time(histogram)
+        def compute() -> int:
+            return 1
+
+        compute()
+
+        assert registry.get_sample_value("bare_seconds_count") == 1
+
+
+class TestPreBoundDecorators:
+    def test_track_feature_compute(self) -> None:
+        @track_feature_compute("degree_centrality")
+        def compute() -> int:
+            return 7
+
+        assert compute() == 7
+        assert _sample("feature_compute_time_count", feature="degree_centrality") == 1
+
+    def test_track_inference(self) -> None:
+        @track_inference("gnn")
+        def predict() -> int:
+            return 1
+
+        predict()
+        assert _sample("model_inference_latency_count", model="gnn") == 1
+
+
+class TestTrackActiveJob:
+    def test_gauge_rises_then_falls(self) -> None:
+        assert _sample("active_jobs", job_type="ingestion") == 0
+
+        with track_active_job("ingestion"):
+            assert _sample("active_jobs", job_type="ingestion") == 1
+
+        assert _sample("active_jobs", job_type="ingestion") == 0
+
+    def test_gauge_is_balanced_on_exception(self) -> None:
+        with pytest.raises(ValueError):
+            with track_active_job("training"):
+                raise ValueError("job failed")
+
+        assert _sample("active_jobs", job_type="training") == 0
+
+    def test_nested_jobs_accumulate(self) -> None:
+        with track_active_job("backfill"):
+            with track_active_job("backfill"):
+                assert _sample("active_jobs", job_type="backfill") == 2
+        assert _sample("active_jobs", job_type="backfill") == 0
+
+
+class TestRenderLatest:
+    def test_exposition_contains_every_metric(self) -> None:
+        observe_http_request("GET", "/metrics", 200, 0.001)
+        body, content_type = render_latest()
+        text = body.decode()
+
+        assert "text/plain" in content_type
+        for name in (
+            "http_request_duration_seconds",
+            "http_requests_total",
+            "db_pool_size",
+            "feature_compute_time",
+            "model_inference_latency",
+            "active_jobs",
+        ):
+            assert name in text
+
+    def test_custom_registry_is_scraped(self) -> None:
+        from prometheus_client import CollectorRegistry, Counter
+
+        registry = CollectorRegistry()
+        Counter("isolated_total", "doc", registry=registry).inc()
+
+        body, _ = render_latest(registry)
+
+        assert "isolated_total" in body.decode()

--- a/tests/test_pr_size_limit.py
+++ b/tests/test_pr_size_limit.py
@@ -1,0 +1,301 @@
+"""Tests for the PR size limit CI policy (Issue #557)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from astroml.ci.pr_size import (
+    COMMENT_MARKER,
+    DEFAULT_THRESHOLDS,
+    LARGE_REFACTOR_LABEL,
+    PullRequestStats,
+    SizeThresholds,
+    evaluate_pr_size,
+    has_large_refactor_label,
+    is_exempt,
+    main,
+    render_comment,
+)
+
+
+def _stats(**overrides: Any) -> PullRequestStats:
+    payload: dict[str, Any] = {
+        "additions": 10,
+        "deletions": 5,
+        "changed_files": 3,
+        "title": "feat: small change",
+        "labels": (),
+    }
+    payload.update(overrides)
+    return PullRequestStats(**payload)
+
+
+class TestPullRequestStats:
+    def test_total_lines_sums_additions_and_deletions(self) -> None:
+        assert _stats(additions=120, deletions=30).total_lines == 150
+
+    def test_from_event_parses_webhook_payload(self) -> None:
+        stats = PullRequestStats.from_event(
+            {
+                "pull_request": {
+                    "additions": 900,
+                    "deletions": 200,
+                    "changed_files": 12,
+                    "title": "refactor: move modules",
+                    "labels": [{"name": "Refactor:Large"}, {"name": "api"}],
+                }
+            }
+        )
+
+        assert stats.total_lines == 1100
+        assert stats.changed_files == 12
+        assert stats.labels == ("refactor:large", "api")
+
+    def test_from_event_accepts_bare_pull_request_object(self) -> None:
+        stats = PullRequestStats.from_event(
+            {"additions": 1, "deletions": 2, "changed_files": 1, "title": "x"}
+        )
+        assert stats.total_lines == 3
+
+    def test_from_event_tolerates_string_labels(self) -> None:
+        stats = PullRequestStats.from_event(
+            {
+                "pull_request": {
+                    "additions": 0,
+                    "deletions": 0,
+                    "changed_files": 0,
+                    "labels": ["Refactor:Large", 7, None],
+                }
+            }
+        )
+        assert stats.labels == ("refactor:large",)
+
+    def test_from_event_rejects_payload_without_pull_request(self) -> None:
+        with pytest.raises(ValueError, match="does not contain a pull_request"):
+            PullRequestStats.from_event({"action": "opened"})
+
+
+class TestExemptions:
+    @pytest.mark.parametrize(
+        "title",
+        ["[large PR] migrate schema", "chore: vendor deps [LARGE PR]"],
+    )
+    def test_title_exemption_is_case_insensitive(self, title: str) -> None:
+        assert is_exempt(title) is True
+
+    def test_title_without_token_is_not_exempt(self) -> None:
+        assert is_exempt("feat: a large pull request") is False
+
+    def test_large_refactor_label_detected(self) -> None:
+        assert has_large_refactor_label([" Refactor:Large "]) is True
+
+    def test_missing_large_refactor_label(self) -> None:
+        assert has_large_refactor_label(["bug", "api"]) is False
+
+
+class TestThresholds:
+    def test_default_file_limit(self) -> None:
+        assert DEFAULT_THRESHOLDS.file_limit(large_refactor=False) == 10
+
+    def test_large_refactor_file_limit(self) -> None:
+        assert DEFAULT_THRESHOLDS.file_limit(large_refactor=True) == 50
+
+
+class TestEvaluatePrSize:
+    def test_small_pr_passes(self) -> None:
+        verdict = evaluate_pr_size(_stats())
+
+        assert verdict.exceeded is False
+        assert verdict.should_comment is False
+        assert verdict.reasons == ()
+
+    def test_boundary_values_are_allowed(self) -> None:
+        verdict = evaluate_pr_size(
+            _stats(additions=1000, deletions=0, changed_files=10)
+        )
+        assert verdict.exceeded is False
+
+    def test_line_limit_breach_reported(self) -> None:
+        verdict = evaluate_pr_size(
+            _stats(additions=900, deletions=200, changed_files=4)
+        )
+
+        assert verdict.exceeded is True
+        assert verdict.should_comment is True
+        assert len(verdict.reasons) == 1
+        assert "1100 lines changed" in verdict.reasons[0]
+
+    def test_file_limit_breach_reported(self) -> None:
+        verdict = evaluate_pr_size(_stats(changed_files=25))
+
+        assert verdict.exceeded is True
+        assert "25 files changed" in verdict.reasons[0]
+        assert "10-file limit" in verdict.reasons[0]
+
+    def test_both_limits_breached(self) -> None:
+        verdict = evaluate_pr_size(
+            _stats(additions=2000, deletions=500, changed_files=40)
+        )
+        assert len(verdict.reasons) == 2
+
+    def test_large_refactor_label_raises_file_ceiling(self) -> None:
+        verdict = evaluate_pr_size(
+            _stats(changed_files=40, labels=(LARGE_REFACTOR_LABEL,))
+        )
+
+        assert verdict.large_refactor is True
+        assert verdict.exceeded is False
+
+    def test_large_refactor_label_still_capped(self) -> None:
+        verdict = evaluate_pr_size(
+            _stats(changed_files=60, labels=(LARGE_REFACTOR_LABEL,))
+        )
+
+        assert verdict.exceeded is True
+        assert "50-file limit for `refactor:large`" in verdict.reasons[0]
+
+    def test_large_refactor_label_does_not_raise_line_ceiling(self) -> None:
+        verdict = evaluate_pr_size(
+            _stats(additions=5000, deletions=0, labels=(LARGE_REFACTOR_LABEL,))
+        )
+        assert verdict.exceeded is True
+
+    def test_title_exemption_suppresses_comment(self) -> None:
+        verdict = evaluate_pr_size(
+            _stats(additions=5000, deletions=0, changed_files=99, title="[large PR] x")
+        )
+
+        assert verdict.exceeded is True
+        assert verdict.exempt is True
+        assert verdict.should_comment is False
+
+    def test_custom_thresholds_are_applied(self) -> None:
+        verdict = evaluate_pr_size(
+            _stats(additions=50, deletions=0, changed_files=1),
+            SizeThresholds(max_lines=10, max_files=1),
+        )
+        assert verdict.exceeded is True
+
+
+class TestRenderComment:
+    def test_comment_contains_marker_and_metrics(self) -> None:
+        verdict = evaluate_pr_size(
+            _stats(additions=900, deletions=300, changed_files=22)
+        )
+        body = render_comment(verdict)
+
+        assert body.startswith(COMMENT_MARKER)
+        assert "| Lines changed | 1200 | 1000 |" in body
+        assert "| Files changed | 22 | 10 |" in body
+        assert "CI is not blocked" in body
+        assert "`refactor:large`" in body
+        assert "`[large PR]`" in body
+
+    def test_comment_lists_every_breached_limit(self) -> None:
+        verdict = evaluate_pr_size(
+            _stats(additions=2000, deletions=0, changed_files=40)
+        )
+        body = render_comment(verdict)
+
+        for reason in verdict.reasons:
+            assert f"- {reason}" in body
+
+    def test_comment_shows_raised_ceiling_for_large_refactor(self) -> None:
+        verdict = evaluate_pr_size(
+            _stats(changed_files=80, labels=(LARGE_REFACTOR_LABEL,))
+        )
+        assert "| Files changed | 80 | 50 |" in render_comment(verdict)
+
+
+class TestMain:
+    @staticmethod
+    def _write_event(tmp_path: Path, pull_request: dict[str, Any]) -> str:
+        event_path = tmp_path / "event.json"
+        event_path.write_text(
+            json.dumps({"pull_request": pull_request}), encoding="utf-8"
+        )
+        return str(event_path)
+
+    def test_main_writes_outputs_for_oversized_pr(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        event = self._write_event(
+            tmp_path,
+            {
+                "additions": 2000,
+                "deletions": 100,
+                "changed_files": 30,
+                "title": "feat: big",
+                "labels": [],
+            },
+        )
+        output = tmp_path / "output.txt"
+        monkeypatch.setenv("GITHUB_OUTPUT", str(output))
+
+        assert main([event]) == 0
+
+        written = output.read_text(encoding="utf-8")
+        assert "exceeded=true" in written
+        assert "should_comment=true" in written
+        assert COMMENT_MARKER in written
+        assert written.count("PR_SIZE_EOF") == 2
+
+    def test_main_writes_empty_body_when_within_limits(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        event = self._write_event(
+            tmp_path,
+            {"additions": 5, "deletions": 5, "changed_files": 2, "title": "fix: typo"},
+        )
+        output = tmp_path / "output.txt"
+        monkeypatch.setenv("GITHUB_OUTPUT", str(output))
+
+        assert main([event]) == 0
+
+        written = output.read_text(encoding="utf-8")
+        assert "exceeded=false" in written
+        assert "should_comment=false" in written
+        assert COMMENT_MARKER not in written
+
+    def test_main_reads_event_path_from_environment(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        event = self._write_event(
+            tmp_path,
+            {"additions": 1, "deletions": 1, "changed_files": 1, "title": "fix"},
+        )
+        monkeypatch.setenv("GITHUB_EVENT_PATH", event)
+        monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+
+        assert main([]) == 0
+
+    def test_main_errors_without_event_path(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("GITHUB_EVENT_PATH", raising=False)
+        assert main([]) == 1
+
+    def test_main_is_exempt_and_skips_comment(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        event = self._write_event(
+            tmp_path,
+            {
+                "additions": 9000,
+                "deletions": 0,
+                "changed_files": 200,
+                "title": "[large PR] vendor deps",
+            },
+        )
+        output = tmp_path / "output.txt"
+        monkeypatch.setenv("GITHUB_OUTPUT", str(output))
+
+        assert main([event]) == 0
+
+        written = output.read_text(encoding="utf-8")
+        assert "exempt=true" in written
+        assert "should_comment=false" in written


### PR DESCRIPTION
## Description

Adds production observability and review-hygiene infrastructure across four related areas: granular health probes, Prometheus metrics coverage, database connection pool health, and soft PR size limits in CI.

Closes #569
Closes #557
Closes #567
Closes #550

> Note: `dev` does not exist on `Traqora/astroml`, so this PR targets `main`.

## What's included

### 🏥 Granular health checks (#569)
- `GET /healthz` — aggregate status
- `GET /healthz/live` — liveness (process up)
- `GET /healthz/ready` — readiness gating (dependencies OK, startup complete)
- `GET /healthz/db` — database connectivity
- `GET /healthz/cache` — Redis connectivity
- `GET /healthz/disk` — disk space availability
- `GET /healthz/startup` — startup probe
- Structured JSON responses with `status` (`ok` / `degraded` / `fail`), per-check `details`, and actionable `remediation` text
- Kubernetes probe manifests

### 📊 Prometheus metrics (#567)
- HTTP request latency histogram and request counter (endpoint + status)
- DB connection pool gauges
- Feature computation timing histogram
- Model inference latency histogram
- Active ingestion jobs gauge
- Reusable decorators/context managers for instrumentation
- `/metrics` exposure with tests
- Metrics reference doc + Grafana dashboard links

### 🗄️ DB connection pool health (#550)
- `pool_pre_ping=True` and connection recycling
- `GET /metrics/db-pool` pool status endpoint
- Pool utilization tracking with a >80% alert threshold
- Wired into the readiness/health checks
- Pool health indicator documentation

### 📏 PR size limits (#557)
- Typed, unit-tested policy module `astroml/ci/pr_size.py`
- `pr-size-limit` workflow: warns via a single self-updating comment, **never fails CI**
- Thresholds: 1000 lines / 10 files; 50 files with the `refactor:large` label
- Opt-out with `[large PR]` in the PR title
- PR template guidance + `docs/PR_SIZE_LIMITS.md`

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Testing

- `pytest tests/`
- `ruff check .`
- `black --check .`
- `mypy astroml/`

## Size

This PR intentionally spans four linked observability issues; it is labelled/titled accordingly.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes
