### PR TITLE
Feature/658 property based testing

### DIFF
--- a/astroml/api/routers/infrastructure.py
+++ b/astroml/api/routers/infrastructure.py
@@ -1,0 +1,126 @@
+"""Infrastructure API endpoints for AstroML.
+
+Provides cost optimization and resource analysis information.
+"""
+
+from __future__ import annotations
+from typing import List
+
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+from astroml.infrastructure.cost_optimizer import CostAllocation, CostOptimizer
+from astroml.infrastructure.recommendations import OptimizationRecommendation, RecommendationEngine
+from astroml.infrastructure.resource_analyzer import ResourceAnalyzer, ResourceMetrics, WorkloadResourceProfile
+
+
+# ---------------------------------------------------------------------------
+# Pydantic response models
+# ---------------------------------------------------------------------------
+
+
+class CostAllocationResponse(BaseModel):
+    """Cost allocation for a single workload."""
+    workload_id: str
+    instance_type: str
+    duration_hours: float
+    hourly_rate: float
+    total_cost: float
+
+
+class OptimizationRecommendationResponse(BaseModel):
+    """Cost saving recommendation."""
+    workload_id: str
+    recommendation_type: str
+    description: str
+    estimated_monthly_savings: float
+
+
+class CostOptimizationSummary(BaseModel):
+    """Summary of cost allocations and recommendations."""
+    total_cost: float
+    allocations: List[CostAllocationResponse]
+    recommendations: List[OptimizationRecommendationResponse]
+
+
+# ---------------------------------------------------------------------------
+# Router setup and mock data generation
+# ---------------------------------------------------------------------------
+
+router = APIRouter()
+
+
+def _get_mock_profiles() -> List[WorkloadResourceProfile]:
+    """Generate mock profiles for the API responses."""
+    return [
+        WorkloadResourceProfile(
+            workload_id="training-job-123",
+            workload_type="training",
+            metrics=ResourceMetrics(cpu_utilization_percent=85.0, memory_utilization_percent=90.0, gpu_utilization_percent=95.0),
+            instance_type="ml.p3.2xlarge",
+            duration_seconds=7200,
+        ),
+        WorkloadResourceProfile(
+            workload_id="inference-svc-456",
+            workload_type="inference",
+            metrics=ResourceMetrics(cpu_utilization_percent=15.0, memory_utilization_percent=25.0, gpu_utilization_percent=None),
+            instance_type="ml.m5.xlarge",
+            duration_seconds=86400,
+        ),
+        WorkloadResourceProfile(
+            workload_id="batch-job-789",
+            workload_type="batch",
+            metrics=ResourceMetrics(cpu_utilization_percent=45.0, memory_utilization_percent=50.0, gpu_utilization_percent=None),
+            instance_type="ml.c5.xlarge",
+            duration_seconds=3600,
+        ),
+        WorkloadResourceProfile(
+            workload_id="idle-job-000",
+            workload_type="training",
+            metrics=ResourceMetrics(cpu_utilization_percent=5.0, memory_utilization_percent=10.0, gpu_utilization_percent=0.0),
+            instance_type="ml.g4dn.xlarge",
+            duration_seconds=18000,
+        )
+    ]
+
+
+@router.get("/api/v1/infrastructure/cost-optimization", response_model=CostOptimizationSummary, tags=["infrastructure"])
+async def get_cost_optimization_summary() -> CostOptimizationSummary:
+    """Get a summary of cost allocations and optimization recommendations."""
+    profiles = _get_mock_profiles()
+    
+    resource_analyzer = ResourceAnalyzer()
+    cost_optimizer = CostOptimizer()
+    recommendation_engine = RecommendationEngine(resource_analyzer)
+
+    allocations_dict = cost_optimizer.build_cost_allocation(profiles)
+    recommendations = recommendation_engine.generate_all_recommendations(profiles, allocations_dict)
+    
+    total_cost = cost_optimizer.calculate_total_cost(allocations_dict)
+
+    allocation_responses = [
+        CostAllocationResponse(
+            workload_id=alloc.workload_id,
+            instance_type=alloc.instance_type,
+            duration_hours=alloc.duration_hours,
+            hourly_rate=alloc.hourly_rate,
+            total_cost=alloc.total_cost,
+        )
+        for alloc in allocations_dict.values()
+    ]
+
+    recommendation_responses = [
+        OptimizationRecommendationResponse(
+            workload_id=rec.workload_id,
+            recommendation_type=rec.recommendation_type,
+            description=rec.description,
+            estimated_monthly_savings=rec.estimated_monthly_savings,
+        )
+        for rec in recommendations
+    ]
+
+    return CostOptimizationSummary(
+        total_cost=total_cost,
+        allocations=allocation_responses,
+        recommendations=recommendation_responses,
+    )

--- a/astroml/documentation/mkdocs_generator.py
+++ b/astroml/documentation/mkdocs_generator.py
@@ -1,0 +1,131 @@
+"""
+MkDocs documentation generator for AstroML.
+
+Generates API documentation, model cards, and pipeline documentation,
+and provides an entrypoint for the CI documentation build process.
+"""
+
+import logging
+from pathlib import Path
+from typing import List, Optional
+
+logger = logging.getLogger(__name__)
+
+def get_project_root() -> Path:
+    """Return the absolute path to the project root directory."""
+    return Path(__file__).resolve().parent.parent.parent
+
+def setup_mkdocs_config(root_dir: Path) -> None:
+    """
+    Set up MkDocs configuration with theme.
+    Search plugin and theme configurations are handled in the YAML.
+    
+    Args:
+        root_dir: The project root directory.
+    """
+    mkdocs_file = root_dir / "docs" / "mkdocs.yml"
+    if not mkdocs_file.exists():
+        logger.warning("docs/mkdocs.yml configuration not found.")
+
+def implement_api_documentation_generation(root_dir: Path) -> None:
+    """
+    Implement API documentation generation.
+    
+    Args:
+        root_dir: The project root directory.
+    """
+    api_dir = root_dir / "docs" / "api"
+    api_dir.mkdir(parents=True, exist_ok=True)
+    index_file = api_dir / "index.md"
+    if not index_file.exists():
+        index_file.write_text("# API Reference\n", encoding="utf-8")
+
+def build_model_card_documentation_pages(root_dir: Path) -> None:
+    """
+    Build model card documentation pages.
+    
+    Args:
+        root_dir: The project root directory.
+    """
+    models_dir = root_dir / "docs" / "models"
+    models_dir.mkdir(parents=True, exist_ok=True)
+    index_file = models_dir / "index.md"
+    if not index_file.exists():
+        index_file.write_text("# Model Cards\n", encoding="utf-8")
+
+def add_pipeline_documentation_generation(root_dir: Path) -> None:
+    """
+    Add pipeline documentation generation.
+    
+    Args:
+        root_dir: The project root directory.
+    """
+    pipelines_dir = root_dir / "docs" / "pipelines"
+    pipelines_dir.mkdir(parents=True, exist_ok=True)
+    index_file = pipelines_dir / "index.md"
+    if not index_file.exists():
+        index_file.write_text("# Pipelines\n", encoding="utf-8")
+
+def add_versioned_documentation(root_dir: Path) -> None:
+    """
+    Add versioned documentation setup.
+    
+    Args:
+        root_dir: The project root directory.
+    """
+    # Versioning functionality placeholder for CI/CD integration (e.g., mike)
+    logger.info("Versioned documentation initialized.")
+
+def implement_search_functionality(root_dir: Path) -> None:
+    """
+    Implement search functionality.
+    
+    Args:
+        root_dir: The project root directory.
+    """
+    # Search is natively enabled via mkdocs.yml search plugin
+    logger.info("Search functionality enabled via configuration.")
+
+def build_docs_for_ci() -> None:
+    """
+    Implement automated doc building in CI.
+    Orchestrates the entire documentation generation process.
+    """
+    root_dir = get_project_root()
+    setup_mkdocs_config(root_dir)
+    implement_search_functionality(root_dir)
+    add_versioned_documentation(root_dir)
+    implement_api_documentation_generation(root_dir)
+    build_model_card_documentation_pages(root_dir)
+    add_pipeline_documentation_generation(root_dir)
+    logger.info("CI documentation build process completed.")
+
+def test_documentation_generation() -> bool:
+    """
+    Test documentation generation.
+    Validates that the required files and directories are created.
+    
+    Returns:
+        True if all files exist, False otherwise.
+    """
+    root_dir = get_project_root()
+    expected_files: List[Path] = [
+        root_dir / "docs" / "mkdocs.yml",
+        root_dir / "docs" / "api" / "index.md",
+        root_dir / "docs" / "models" / "index.md",
+        root_dir / "docs" / "pipelines" / "index.md",
+    ]
+    
+    build_docs_for_ci()
+    
+    missing_files = [f for f in expected_files if not f.exists()]
+    if missing_files:
+        logger.error(f"Documentation generation test failed. Missing: {missing_files}")
+        return False
+        
+    logger.info("Documentation generation test passed successfully.")
+    return True
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    test_documentation_generation()

--- a/astroml/infrastructure/__init__.py
+++ b/astroml/infrastructure/__init__.py
@@ -1,0 +1,15 @@
+"""Infrastructure cost optimization and resource analysis modules."""
+
+from astroml.infrastructure.cost_optimizer import CostAllocation, CostOptimizer
+from astroml.infrastructure.recommendations import OptimizationRecommendation, RecommendationEngine
+from astroml.infrastructure.resource_analyzer import ResourceAnalyzer, ResourceMetrics, WorkloadResourceProfile
+
+__all__ = [
+    "CostAllocation",
+    "CostOptimizer",
+    "OptimizationRecommendation",
+    "RecommendationEngine",
+    "ResourceAnalyzer",
+    "ResourceMetrics",
+    "WorkloadResourceProfile",
+]

--- a/astroml/infrastructure/cost_optimizer.py
+++ b/astroml/infrastructure/cost_optimizer.py
@@ -1,0 +1,62 @@
+"""Cost optimization and allocation for ML workloads."""
+
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Dict, List
+
+from astroml.infrastructure.resource_analyzer import WorkloadResourceProfile
+
+
+@dataclass
+class CostAllocation:
+    """Cost allocation for a specific workload."""
+    workload_id: str
+    instance_type: str
+    duration_hours: float
+    hourly_rate: float
+    total_cost: float
+
+
+class CostOptimizer:
+    """Calculates costs and optimizations for ML workloads."""
+
+    # Mock pricing table (USD/hr)
+    PRICING_TABLE = {
+        "ml.m5.large": 0.115,
+        "ml.m5.xlarge": 0.23,
+        "ml.c5.xlarge": 0.204,
+        "ml.p3.2xlarge": 3.825,
+        "ml.g4dn.xlarge": 0.736,
+    }
+
+    def __init__(self) -> None:
+        pass
+
+    def get_hourly_rate(self, instance_type: str) -> float:
+        """Get the hourly rate for an instance type. Defaults to a standard rate if unknown."""
+        return self.PRICING_TABLE.get(instance_type, 0.50)
+
+    def calculate_workload_cost(self, profile: WorkloadResourceProfile) -> CostAllocation:
+        """Calculate the cost allocation for a single workload profile."""
+        duration_hours = profile.duration_seconds / 3600.0
+        hourly_rate = self.get_hourly_rate(profile.instance_type)
+        total_cost = duration_hours * hourly_rate
+
+        return CostAllocation(
+            workload_id=profile.workload_id,
+            instance_type=profile.instance_type,
+            duration_hours=duration_hours,
+            hourly_rate=hourly_rate,
+            total_cost=total_cost,
+        )
+
+    def build_cost_allocation(self, profiles: List[WorkloadResourceProfile]) -> Dict[str, CostAllocation]:
+        """Build cost allocations for a list of workloads."""
+        allocations = {}
+        for profile in profiles:
+            allocations[profile.workload_id] = self.calculate_workload_cost(profile)
+        return allocations
+
+    def calculate_total_cost(self, allocations: Dict[str, CostAllocation]) -> float:
+        """Calculate the total cost across all allocations."""
+        return sum(allocation.total_cost for allocation in allocations.values())

--- a/astroml/infrastructure/recommendations.py
+++ b/astroml/infrastructure/recommendations.py
@@ -1,0 +1,111 @@
+"""Recommendation engine for cost optimization."""
+
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import List
+
+from astroml.infrastructure.cost_optimizer import CostAllocation
+from astroml.infrastructure.resource_analyzer import ResourceAnalyzer, WorkloadResourceProfile
+
+
+@dataclass
+class OptimizationRecommendation:
+    """A specific cost optimization recommendation."""
+    workload_id: str
+    recommendation_type: str  # e.g., 'spot_instance', 'auto_scaling', 'right_sizing'
+    description: str
+    estimated_monthly_savings: float
+
+
+class RecommendationEngine:
+    """Generates cost-saving recommendations for ML workloads."""
+
+    def __init__(self, resource_analyzer: ResourceAnalyzer) -> None:
+        self.resource_analyzer = resource_analyzer
+        # Spot instance discount rate is typically around 70% cheaper
+        self.spot_discount = 0.70
+
+    def add_spot_instance_recommendation(
+        self, profile: WorkloadResourceProfile, allocation: CostAllocation
+    ) -> OptimizationRecommendation | None:
+        """
+        Recommend spot instances for batch or non-critical workloads.
+        Assume 'batch' workloads are interruptible.
+        """
+        if profile.workload_type.lower() == "batch":
+            monthly_cost = allocation.total_cost * (730 / (profile.duration_seconds / 3600.0) if profile.duration_seconds > 0 else 0)
+            # If the workload only ran once, let's scale it to monthly based on an assumed schedule,
+            # or simply use the total cost as a baseline if it's continuous.
+            # To simplify, we calculate savings per 730 hours (1 month) based on the hourly rate.
+            monthly_savings = allocation.hourly_rate * 730 * self.spot_discount
+
+            return OptimizationRecommendation(
+                workload_id=profile.workload_id,
+                recommendation_type="spot_instance",
+                description=f"Use Spot Instances for batch workload {profile.workload_id} to save up to 70%.",
+                estimated_monthly_savings=monthly_savings,
+            )
+        return None
+
+    def implement_auto_scaling_optimization(
+        self, profile: WorkloadResourceProfile, allocation: CostAllocation
+    ) -> OptimizationRecommendation | None:
+        """
+        Recommend auto-scaling if the workload shows spiky or low utilization, 
+        particularly for inference endpoints.
+        """
+        scores = self.resource_analyzer.analyze_utilization(profile)
+        # If max utilization is below 40% and it's an inference workload, recommend auto-scaling down
+        if profile.workload_type.lower() == "inference" and max(scores.values()) < 0.4:
+            # Assume auto-scaling can save 30% of the cost by spinning down during idle times
+            monthly_savings = allocation.hourly_rate * 730 * 0.30
+            return OptimizationRecommendation(
+                workload_id=profile.workload_id,
+                recommendation_type="auto_scaling",
+                description=f"Enable auto-scaling for inference workload {profile.workload_id} due to low average utilization.",
+                estimated_monthly_savings=monthly_savings,
+            )
+        return None
+
+    def add_savings_opportunity_identification(
+        self, profile: WorkloadResourceProfile, allocation: CostAllocation
+    ) -> OptimizationRecommendation | None:
+        """
+        Identify general savings opportunities, such as right-sizing an instance.
+        """
+        scores = self.resource_analyzer.analyze_utilization(profile)
+        # If all utilizations are extremely low (<20%), recommend a smaller instance
+        if all(score < 0.2 for score in scores.values()):
+            # Assume downsizing halves the cost
+            monthly_savings = allocation.hourly_rate * 730 * 0.50
+            return OptimizationRecommendation(
+                workload_id=profile.workload_id,
+                recommendation_type="right_sizing",
+                description=f"Downsize instance {profile.instance_type} for workload {profile.workload_id} due to <20% utilization.",
+                estimated_monthly_savings=monthly_savings,
+            )
+        return None
+
+    def generate_all_recommendations(
+        self, profiles: List[WorkloadResourceProfile], allocations: dict[str, CostAllocation]
+    ) -> List[OptimizationRecommendation]:
+        """Generate all possible recommendations for the given workloads."""
+        recommendations = []
+        for profile in profiles:
+            allocation = allocations.get(profile.workload_id)
+            if not allocation:
+                continue
+
+            spot_rec = self.add_spot_instance_recommendation(profile, allocation)
+            if spot_rec:
+                recommendations.append(spot_rec)
+
+            as_rec = self.implement_auto_scaling_optimization(profile, allocation)
+            if as_rec:
+                recommendations.append(as_rec)
+
+            rs_rec = self.add_savings_opportunity_identification(profile, allocation)
+            if rs_rec:
+                recommendations.append(rs_rec)
+
+        return recommendations

--- a/astroml/infrastructure/resource_analyzer.py
+++ b/astroml/infrastructure/resource_analyzer.py
@@ -1,0 +1,60 @@
+"""Resource utilization analysis for ML workloads."""
+
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Dict, List
+
+
+@dataclass
+class ResourceMetrics:
+    """Metrics for a specific resource type."""
+    cpu_utilization_percent: float
+    memory_utilization_percent: float
+    gpu_utilization_percent: float | None = None
+    memory_bytes_used: int = 0
+    memory_bytes_total: int = 0
+
+
+@dataclass
+class WorkloadResourceProfile:
+    """Resource profile for a specific ML workload."""
+    workload_id: str
+    workload_type: str  # e.g., 'training', 'inference', 'batch'
+    metrics: ResourceMetrics
+    instance_type: str
+    duration_seconds: float
+
+
+class ResourceAnalyzer:
+    """Analyzes resource utilization of ML workloads."""
+
+    def __init__(self) -> None:
+        pass
+
+    def analyze_utilization(self, profile: WorkloadResourceProfile) -> Dict[str, float]:
+        """
+        Analyze resource utilization and return utilization scores.
+        Scores are 0.0 (idle) to 1.0 (fully utilized).
+        """
+        scores = {
+            "cpu_score": profile.metrics.cpu_utilization_percent / 100.0,
+            "memory_score": profile.metrics.memory_utilization_percent / 100.0,
+        }
+        if profile.metrics.gpu_utilization_percent is not None:
+            scores["gpu_score"] = profile.metrics.gpu_utilization_percent / 100.0
+
+        return scores
+
+    def identify_underutilized_resources(
+        self, profiles: List[WorkloadResourceProfile], threshold: float = 0.3
+    ) -> List[WorkloadResourceProfile]:
+        """
+        Identify workloads that are consistently underutilizing their allocated resources.
+        A workload is considered underutilized if all active resource scores are below the threshold.
+        """
+        underutilized = []
+        for profile in profiles:
+            scores = self.analyze_utilization(profile)
+            if all(score < threshold for score in scores.values()):
+                underutilized.append(profile)
+        return underutilized

--- a/astroml/testing/__init__.py
+++ b/astroml/testing/__init__.py
@@ -1,0 +1,1 @@
+"""Testing utilities for AstroML ML workloads."""

--- a/astroml/testing/property_based/__init__.py
+++ b/astroml/testing/property_based/__init__.py
@@ -1,0 +1,1 @@
+"""Property-based testing subpackage for AstroML ML workloads."""

--- a/astroml/testing/property_based/data_properties.py
+++ b/astroml/testing/property_based/data_properties.py
@@ -1,0 +1,289 @@
+"""Data property validation for ML datasets.
+
+Implements Procedure step 5:
+  5. Implement data property validation.
+
+This module defines validation functions that assert structural and statistical
+properties of raw ML datasets (feature matrices and label arrays) prior to
+model training or evaluation.  Every validator returns a
+:class:`DataValidationResult` that callers can inspect or log.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Optional, Sequence
+
+import numpy as np
+
+
+# ── Result data class ─────────────────────────────────────────────────────────
+
+
+@dataclass
+class DataValidationResult:
+    """Outcome of a single data validation check.
+
+    Attributes:
+        check_name: Human-readable name of the validation check.
+        passed: ``True`` if the data satisfied the property.
+        error_message: Description of the failure, or ``None`` on success.
+    """
+
+    check_name: str
+    passed: bool
+    error_message: Optional[str] = None
+
+
+# ── Individual validation functions ──────────────────────────────────────────
+
+
+def check_no_nan_or_inf(X: np.ndarray) -> DataValidationResult:
+    """Verify that *X* contains no NaN or infinite values.
+
+    Args:
+        X: Feature matrix to inspect.
+
+    Returns:
+        A :class:`DataValidationResult` indicating pass or fail.
+    """
+    if not np.all(np.isfinite(X)):
+        nan_count = int(np.sum(np.isnan(X)))
+        inf_count = int(np.sum(np.isinf(X)))
+        return DataValidationResult(
+            check_name="no_nan_or_inf",
+            passed=False,
+            error_message=(
+                f"Feature matrix contains {nan_count} NaN(s) and "
+                f"{inf_count} infinite value(s)."
+            ),
+        )
+    return DataValidationResult(check_name="no_nan_or_inf", passed=True)
+
+
+def check_feature_matrix_shape(
+    X: np.ndarray,
+    expected_features: Optional[int] = None,
+) -> DataValidationResult:
+    """Verify that *X* is 2-D and optionally matches an expected column count.
+
+    Args:
+        X: Feature matrix to inspect.
+        expected_features: If provided, the exact number of columns required.
+
+    Returns:
+        A :class:`DataValidationResult` indicating pass or fail.
+    """
+    if X.ndim != 2:
+        return DataValidationResult(
+            check_name="feature_matrix_shape",
+            passed=False,
+            error_message=f"Expected 2-D array, got {X.ndim}-D array.",
+        )
+    if expected_features is not None and X.shape[1] != expected_features:
+        return DataValidationResult(
+            check_name="feature_matrix_shape",
+            passed=False,
+            error_message=(
+                f"Expected {expected_features} features, got {X.shape[1]}."
+            ),
+        )
+    return DataValidationResult(check_name="feature_matrix_shape", passed=True)
+
+
+def check_label_array_shape(
+    y: np.ndarray,
+    X: np.ndarray,
+) -> DataValidationResult:
+    """Verify that label array *y* has the same length as *X*.
+
+    Args:
+        y: 1-D label array.
+        X: Feature matrix used to infer the expected sample count.
+
+    Returns:
+        A :class:`DataValidationResult` indicating pass or fail.
+    """
+    if y.ndim != 1:
+        return DataValidationResult(
+            check_name="label_array_shape",
+            passed=False,
+            error_message=f"Label array must be 1-D, got {y.ndim}-D.",
+        )
+    if len(y) != X.shape[0]:
+        return DataValidationResult(
+            check_name="label_array_shape",
+            passed=False,
+            error_message=(
+                f"Label count {len(y)} does not match sample count "
+                f"{X.shape[0]}."
+            ),
+        )
+    return DataValidationResult(check_name="label_array_shape", passed=True)
+
+
+def check_class_labels_in_range(
+    y: np.ndarray,
+    n_classes: int,
+) -> DataValidationResult:
+    """Verify that all labels are integers in ``[0, n_classes)``.
+
+    Args:
+        y: 1-D label array.
+        n_classes: Total number of expected classes.
+
+    Returns:
+        A :class:`DataValidationResult` indicating pass or fail.
+    """
+    invalid = y[(y < 0) | (y >= n_classes)]
+    if len(invalid) > 0:
+        return DataValidationResult(
+            check_name="class_labels_in_range",
+            passed=False,
+            error_message=(
+                f"Found {len(invalid)} label(s) outside [0, {n_classes}): "
+                f"{np.unique(invalid).tolist()}"
+            ),
+        )
+    return DataValidationResult(check_name="class_labels_in_range", passed=True)
+
+
+def check_minimum_samples(
+    X: np.ndarray,
+    min_samples: int = 1,
+) -> DataValidationResult:
+    """Verify that *X* contains at least *min_samples* rows.
+
+    Args:
+        X: Feature matrix to inspect.
+        min_samples: Minimum number of samples required.
+
+    Returns:
+        A :class:`DataValidationResult` indicating pass or fail.
+    """
+    if X.shape[0] < min_samples:
+        return DataValidationResult(
+            check_name="minimum_samples",
+            passed=False,
+            error_message=(
+                f"Dataset has {X.shape[0]} sample(s); at least "
+                f"{min_samples} required."
+            ),
+        )
+    return DataValidationResult(check_name="minimum_samples", passed=True)
+
+
+def check_feature_variance(
+    X: np.ndarray,
+    min_variance: float = 0.0,
+) -> DataValidationResult:
+    """Verify that no feature column has variance below *min_variance*.
+
+    Constant features (variance = 0) can cause numerical instability in many
+    algorithms; this check surfaces such columns early.
+
+    Args:
+        X: Feature matrix of shape ``(n_samples, n_features)``.
+        min_variance: Minimum acceptable per-column variance.
+
+    Returns:
+        A :class:`DataValidationResult` indicating pass or fail.
+    """
+    if X.shape[0] < 2:
+        # Variance is undefined with a single sample.
+        return DataValidationResult(
+            check_name="feature_variance",
+            passed=True,
+        )
+    variances = X.var(axis=0)
+    low_var_cols: List[int] = [
+        int(i) for i, v in enumerate(variances) if v <= min_variance
+    ]
+    if low_var_cols:
+        return DataValidationResult(
+            check_name="feature_variance",
+            passed=False,
+            error_message=(
+                f"Columns {low_var_cols} have variance <= {min_variance}."
+            ),
+        )
+    return DataValidationResult(check_name="feature_variance", passed=True)
+
+
+# ── Composite validator ───────────────────────────────────────────────────────
+
+
+@dataclass
+class DataPropertyValidator:
+    """Run a battery of data validation checks against a feature matrix.
+
+    Usage::
+
+        validator = DataPropertyValidator(expected_features=10, n_classes=2)
+        results = validator.validate(X, y)
+
+    Attributes:
+        expected_features: If set, :func:`check_feature_matrix_shape` will
+            enforce this column count.
+        n_classes: If set together with *y*, labels are validated to be in
+            ``[0, n_classes)``.
+        min_samples: Minimum required sample count.
+        min_variance: Minimum acceptable per-feature variance; set to ``0.0``
+            to skip constant-feature detection.
+    """
+
+    expected_features: Optional[int] = None
+    n_classes: Optional[int] = None
+    min_samples: int = 1
+    min_variance: float = 0.0
+
+    def validate(
+        self,
+        X: np.ndarray,
+        y: Optional[np.ndarray] = None,
+    ) -> List[DataValidationResult]:
+        """Run all configured validation checks.
+
+        Args:
+            X: Feature matrix to validate.
+            y: Optional label array; if provided, label-specific checks are
+               also executed.
+
+        Returns:
+            A list of :class:`DataValidationResult` instances, one per check.
+        """
+        results: List[DataValidationResult] = []
+
+        results.append(check_no_nan_or_inf(X))
+        results.append(
+            check_feature_matrix_shape(X, expected_features=self.expected_features)
+        )
+        results.append(check_minimum_samples(X, min_samples=self.min_samples))
+        results.append(
+            check_feature_variance(X, min_variance=self.min_variance)
+        )
+
+        if y is not None:
+            results.append(check_label_array_shape(y, X))
+            if self.n_classes is not None:
+                results.append(
+                    check_class_labels_in_range(y, n_classes=self.n_classes)
+                )
+
+        return results
+
+    def all_passed(
+        self,
+        X: np.ndarray,
+        y: Optional[np.ndarray] = None,
+    ) -> bool:
+        """Return ``True`` only if every validation check passes.
+
+        Args:
+            X: Feature matrix to validate.
+            y: Optional label array.
+
+        Returns:
+            ``True`` when no check fails.
+        """
+        return all(r.passed for r in self.validate(X, y))

--- a/astroml/testing/property_based/invariant_checker.py
+++ b/astroml/testing/property_based/invariant_checker.py
@@ -1,0 +1,257 @@
+"""Invariant checker for ML model outputs.
+
+Implements Procedure step 4:
+  4. Add invariant checking for model outputs.
+
+An *invariant* is a condition that must hold for **every** prediction a model
+produces, regardless of the specific input.  This module provides:
+
+* :class:`InvariantViolation` — structured description of a failed invariant.
+* :class:`InvariantChecker` — registers named invariants and checks them
+  against a batch of model outputs, collecting all violations.
+* :func:`create_standard_invariant_checker` — convenience factory that
+  pre-registers the most common ML output invariants.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable, Dict, List, Optional
+
+import numpy as np
+
+
+# ── Type alias ────────────────────────────────────────────────────────────────
+
+InvariantFn = Callable[[np.ndarray, np.ndarray], bool]
+
+
+# ── Violation record ──────────────────────────────────────────────────────────
+
+
+@dataclass
+class InvariantViolation:
+    """Structured record of a single invariant violation.
+
+    Attributes:
+        invariant_name: Identifier of the invariant that was violated.
+        sample_index: Row index in the input batch that triggered the
+            violation, or ``None`` when the invariant operates on the
+            whole output tensor.
+        input_sample: The specific input row (or full matrix) that triggered
+            the violation.
+        model_output: The model output that violated the invariant.
+        description: Human-readable explanation of the violation.
+    """
+
+    invariant_name: str
+    sample_index: Optional[int]
+    input_sample: np.ndarray
+    model_output: np.ndarray
+    description: str
+
+
+# ── Invariant checker ─────────────────────────────────────────────────────────
+
+
+@dataclass
+class InvariantChecker:
+    """Register and evaluate invariants against batches of model outputs.
+
+    Usage::
+
+        checker = InvariantChecker()
+        checker.register("finite", lambda X, y: np.all(np.isfinite(y)))
+        violations = checker.check(X_batch, predictions)
+
+    Attributes:
+        _invariants: Internal mapping from invariant name to its callable.
+        _violations: Accumulated violations from the most recent
+            :meth:`check` call.
+    """
+
+    _invariants: Dict[str, InvariantFn] = field(default_factory=dict, init=False)
+    _violations: List[InvariantViolation] = field(default_factory=list, init=False)
+
+    def register(self, name: str, fn: InvariantFn) -> None:
+        """Register a named invariant function.
+
+        Args:
+            name: Unique identifier for the invariant.
+            fn: Callable ``(X, output) -> bool``; return ``True`` if the
+                invariant holds.
+
+        Raises:
+            ValueError: If *name* is already registered.
+        """
+        if name in self._invariants:
+            raise ValueError(
+                f"Invariant '{name}' is already registered. "
+                "Use a different name or remove it first."
+            )
+        self._invariants[name] = fn
+
+    def remove(self, name: str) -> None:
+        """Remove a previously registered invariant.
+
+        Args:
+            name: Name of the invariant to remove.
+
+        Raises:
+            KeyError: If *name* is not registered.
+        """
+        if name not in self._invariants:
+            raise KeyError(f"Invariant '{name}' is not registered.")
+        del self._invariants[name]
+
+    def check(
+        self,
+        X: np.ndarray,
+        output: np.ndarray,
+    ) -> List[InvariantViolation]:
+        """Evaluate all registered invariants against *output*.
+
+        Each invariant is called with the full *(X, output)* pair.  If an
+        invariant returns ``False``, an :class:`InvariantViolation` is
+        recorded.
+
+        Args:
+            X: Input feature matrix of shape ``(n_samples, n_features)``.
+            output: Model output array of shape ``(n_samples, ...)``.
+
+        Returns:
+            A list of :class:`InvariantViolation` instances for every
+            invariant that failed.  An empty list means all invariants passed.
+        """
+        self._violations = []
+        for name, fn in self._invariants.items():
+            try:
+                passed = fn(X, output)
+            except Exception as exc:
+                self._violations.append(
+                    InvariantViolation(
+                        invariant_name=name,
+                        sample_index=None,
+                        input_sample=X,
+                        model_output=output,
+                        description=f"Invariant '{name}' raised an exception: {exc}",
+                    )
+                )
+                continue
+
+            if not passed:
+                self._violations.append(
+                    InvariantViolation(
+                        invariant_name=name,
+                        sample_index=None,
+                        input_sample=X,
+                        model_output=output,
+                        description=(
+                            f"Invariant '{name}' failed for output of "
+                            f"shape {output.shape}."
+                        ),
+                    )
+                )
+        return list(self._violations)
+
+    def check_per_sample(
+        self,
+        X: np.ndarray,
+        output: np.ndarray,
+    ) -> List[InvariantViolation]:
+        """Evaluate invariants row-by-row, reporting the first failing sample.
+
+        This is slower than :meth:`check` but provides precise
+        ``sample_index`` attribution in violations.
+
+        Args:
+            X: Input feature matrix of shape ``(n_samples, n_features)``.
+            output: Model output array of shape ``(n_samples, ...)``.
+
+        Returns:
+            A list of :class:`InvariantViolation` instances; ``sample_index``
+            is set to the index of the first row that violated each invariant.
+        """
+        self._violations = []
+        n_samples = X.shape[0]
+
+        for name, fn in self._invariants.items():
+            for i in range(n_samples):
+                xi = X[i : i + 1]
+                yi = output[i : i + 1]
+                try:
+                    passed = fn(xi, yi)
+                except Exception as exc:
+                    self._violations.append(
+                        InvariantViolation(
+                            invariant_name=name,
+                            sample_index=i,
+                            input_sample=xi,
+                            model_output=yi,
+                            description=(
+                                f"Invariant '{name}' raised at sample {i}: {exc}"
+                            ),
+                        )
+                    )
+                    break
+
+                if not passed:
+                    self._violations.append(
+                        InvariantViolation(
+                            invariant_name=name,
+                            sample_index=i,
+                            input_sample=xi,
+                            model_output=yi,
+                            description=(
+                                f"Invariant '{name}' violated at sample "
+                                f"{i}: output={yi!r}"
+                            ),
+                        )
+                    )
+                    break  # Report only the first violating sample per invariant
+
+        return list(self._violations)
+
+    @property
+    def violations(self) -> List[InvariantViolation]:
+        """Return violations recorded by the most recent :meth:`check` call."""
+        return list(self._violations)
+
+    @property
+    def registered_names(self) -> List[str]:
+        """Return the names of all registered invariants."""
+        return list(self._invariants.keys())
+
+
+# ── Convenience factory ───────────────────────────────────────────────────────
+
+
+def create_standard_invariant_checker() -> InvariantChecker:
+    """Return an :class:`InvariantChecker` pre-loaded with common invariants.
+
+    The following invariants are registered:
+
+    * ``"finite_outputs"`` — all output values are finite.
+    * ``"non_negative_probabilities"`` — outputs are >= 0 (suitable for
+      probability or score models).
+    * ``"output_shape_consistent"`` — output has at least as many rows as *X*.
+
+    Returns:
+        A fully configured :class:`InvariantChecker`.
+    """
+    checker = InvariantChecker()
+
+    checker.register(
+        "finite_outputs",
+        lambda X, output: bool(np.all(np.isfinite(output))),
+    )
+    checker.register(
+        "non_negative_probabilities",
+        lambda X, output: bool(np.all(output >= 0.0)),
+    )
+    checker.register(
+        "output_shape_consistent",
+        lambda X, output: output.shape[0] == X.shape[0],
+    )
+
+    return checker

--- a/astroml/testing/property_based/model_properties.py
+++ b/astroml/testing/property_based/model_properties.py
@@ -1,0 +1,274 @@
+"""Model invariant definitions and property-based test runner for ML models.
+
+Implements Procedure steps 1 and 3:
+  1. Define model invariants and properties.
+  3. Build property-based test runner.
+
+A *model property* is a callable ``(X, output) -> bool`` that asserts a
+behavioural invariant that must hold for **every** input/output pair produced
+by a model.  The :class:`ModelPropertyRunner` wires properties together with
+Hypothesis and reports any violations.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable, Dict, List, Optional, Sequence
+
+import numpy as np
+from hypothesis import HealthCheck, Phase, given, settings
+from hypothesis import strategies as st
+
+from astroml.testing.property_based.strategies import (
+    feature_matrix_strategy,
+    probability_output_strategy,
+)
+
+
+# ── Type aliases ──────────────────────────────────────────────────────────────
+
+ModelCallable = Callable[[np.ndarray], np.ndarray]
+PropertyFn = Callable[[np.ndarray, np.ndarray], bool]
+
+
+# ── Built-in invariants ───────────────────────────────────────────────────────
+
+
+def outputs_are_finite(X: np.ndarray, output: np.ndarray) -> bool:
+    """Check that all model outputs are finite (no NaN or Inf).
+
+    Args:
+        X: Input feature matrix (unused, kept for uniform signature).
+        output: Model output array.
+
+    Returns:
+        ``True`` if every element of *output* is finite.
+    """
+    return bool(np.all(np.isfinite(output)))
+
+
+def output_shape_matches_samples(X: np.ndarray, output: np.ndarray) -> bool:
+    """Check that the output leading dimension equals the number of samples.
+
+    Args:
+        X: Input feature matrix of shape ``(n_samples, n_features)``.
+        output: Model output array; its first dimension must equal
+            ``X.shape[0]``.
+
+    Returns:
+        ``True`` if ``output.shape[0] == X.shape[0]``.
+    """
+    return output.shape[0] == X.shape[0]
+
+
+def binary_predictions_in_set(X: np.ndarray, output: np.ndarray) -> bool:
+    """Check that every element of a binary prediction array is 0 or 1.
+
+    Args:
+        X: Input feature matrix (unused).
+        output: 1-D integer prediction array.
+
+    Returns:
+        ``True`` if all values are in ``{0, 1}``.
+    """
+    return bool(np.all(np.isin(output, [0, 1])))
+
+
+def probability_rows_sum_to_one(X: np.ndarray, output: np.ndarray) -> bool:
+    """Check that each row of a probability matrix sums to approximately 1.
+
+    Args:
+        X: Input feature matrix (unused).
+        output: 2-D probability matrix of shape ``(n_samples, n_classes)``.
+
+    Returns:
+        ``True`` if every row sum is within 1e-5 of 1.0.
+    """
+    if output.ndim != 2:
+        return False
+    row_sums = output.sum(axis=1)
+    return bool(np.all(np.abs(row_sums - 1.0) < 1e-5))
+
+
+def scores_in_unit_interval(X: np.ndarray, output: np.ndarray) -> bool:
+    """Check that all scalar scores are in [0, 1].
+
+    Args:
+        X: Input feature matrix (unused).
+        output: Array of scalar scores.
+
+    Returns:
+        ``True`` if every score is in ``[0, 1]``.
+    """
+    return bool(np.all((output >= 0.0) & (output <= 1.0)))
+
+
+# ── Registry of built-in properties ──────────────────────────────────────────
+
+BUILTIN_PROPERTIES: Dict[str, PropertyFn] = {
+    "outputs_are_finite": outputs_are_finite,
+    "output_shape_matches_samples": output_shape_matches_samples,
+    "binary_predictions_in_set": binary_predictions_in_set,
+    "probability_rows_sum_to_one": probability_rows_sum_to_one,
+    "scores_in_unit_interval": scores_in_unit_interval,
+}
+
+
+# ── Result data class ─────────────────────────────────────────────────────────
+
+
+@dataclass
+class PropertyCheckResult:
+    """Result of a single property check against one model.
+
+    Attributes:
+        property_name: Human-readable name of the property.
+        passed: ``True`` if the property held for all tested inputs.
+        violation_input: The input array that triggered a violation, or
+            ``None`` if the property passed.
+        violation_output: The output array produced for the violating input,
+            or ``None`` if the property passed.
+        error_message: Descriptive error string on failure, or ``None``.
+    """
+
+    property_name: str
+    passed: bool
+    violation_input: Optional[np.ndarray] = None
+    violation_output: Optional[np.ndarray] = None
+    error_message: Optional[str] = None
+
+
+# ── Runner ────────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class ModelPropertyRunner:
+    """Run a set of property-based checks against a model callable.
+
+    Usage::
+
+        runner = ModelPropertyRunner(
+            model=my_model.predict,
+            properties=[outputs_are_finite, output_shape_matches_samples],
+            n_features=10,
+        )
+        results = runner.run(max_examples=100)
+
+    Attributes:
+        model: Callable ``(X: np.ndarray) -> np.ndarray`` representing the
+            model under test.
+        properties: Sequence of property functions to check.
+        n_features: Number of input features expected by *model*.
+        max_samples: Maximum batch size to generate per example.
+        _results: Internal list populated after :meth:`run` is called.
+    """
+
+    model: ModelCallable
+    properties: Sequence[PropertyFn]
+    n_features: int
+    max_samples: int = 30
+    _results: List[PropertyCheckResult] = field(default_factory=list, init=False)
+
+    def run(self, max_examples: int = 50) -> List[PropertyCheckResult]:
+        """Execute all registered properties via Hypothesis.
+
+        For each property, a ``@given`` test is constructed inline and run.
+        Violations are captured and returned rather than raised.
+
+        Args:
+            max_examples: Maximum Hypothesis examples per property.
+
+        Returns:
+            A list of :class:`PropertyCheckResult` instances—one per property.
+        """
+        self._results = []
+        for prop in self.properties:
+            result = self._check_property(prop, max_examples=max_examples)
+            self._results.append(result)
+        return list(self._results)
+
+    def _check_property(
+        self,
+        prop: PropertyFn,
+        max_examples: int,
+    ) -> PropertyCheckResult:
+        """Run a single property against the model.
+
+        Args:
+            prop: The property function to verify.
+            max_examples: Maximum Hypothesis examples to generate.
+
+        Returns:
+            A :class:`PropertyCheckResult` describing the outcome.
+        """
+        n_features = self.n_features
+        max_samples = self.max_samples
+        model = self.model
+        prop_name = prop.__name__
+
+        violation: List[tuple[np.ndarray, np.ndarray, str]] = []
+
+        @given(
+            X=feature_matrix_strategy(
+                min_samples=1,
+                max_samples=max_samples,
+                min_features=n_features,
+                max_features=n_features,
+            )
+        )
+        @settings(
+            max_examples=max_examples,
+            deadline=None,
+            phases=[Phase.generate, Phase.shrink],
+            suppress_health_check=[HealthCheck.too_slow],
+        )
+        def _inner(X: np.ndarray) -> None:
+            try:
+                output = model(X)
+            except Exception as exc:
+                violation.append((X, np.array([]), f"Model raised: {exc}"))
+                return
+            if not prop(X, output):
+                violation.append(
+                    (
+                        X,
+                        output,
+                        f"Property '{prop_name}' violated on output {output!r}",
+                    )
+                )
+
+        try:
+            _inner()
+        except Exception as exc:
+            # Hypothesis itself raises AssertionError on shrunk counterexample
+            if violation:
+                inp, out, msg = violation[0]
+                return PropertyCheckResult(
+                    property_name=prop_name,
+                    passed=False,
+                    violation_input=inp,
+                    violation_output=out,
+                    error_message=msg,
+                )
+            return PropertyCheckResult(
+                property_name=prop_name,
+                passed=False,
+                error_message=str(exc),
+            )
+
+        if violation:
+            inp, out, msg = violation[0]
+            return PropertyCheckResult(
+                property_name=prop_name,
+                passed=False,
+                violation_input=inp,
+                violation_output=out,
+                error_message=msg,
+            )
+
+        return PropertyCheckResult(property_name=prop_name, passed=True)
+
+    @property
+    def results(self) -> List[PropertyCheckResult]:
+        """Return the results from the most recent :meth:`run` call."""
+        return list(self._results)

--- a/astroml/testing/property_based/strategies.py
+++ b/astroml/testing/property_based/strategies.py
@@ -1,0 +1,151 @@
+"""Hypothesis strategies for ML data generation.
+
+Provides reusable Hypothesis strategies that generate realistic ML inputs
+such as feature matrices, label arrays, and raw model output vectors.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from hypothesis import strategies as st
+from hypothesis.extra import numpy as np_st
+
+
+# ── Feature matrix strategies ─────────────────────────────────────────────────
+
+
+def feature_matrix_strategy(
+    min_samples: int = 1,
+    max_samples: int = 50,
+    min_features: int = 1,
+    max_features: int = 20,
+) -> st.SearchStrategy[np.ndarray]:
+    """Return a strategy that draws 2-D float32 feature matrices.
+
+    Args:
+        min_samples: Minimum number of rows (samples).
+        max_samples: Maximum number of rows (samples).
+        min_features: Minimum number of columns (features).
+        max_features: Maximum number of columns (features).
+
+    Returns:
+        A Hypothesis strategy producing ``np.ndarray`` of shape
+        ``(n_samples, n_features)`` with dtype ``float32``.
+    """
+    return np_st.arrays(
+        dtype=np.float32,
+        shape=st.tuples(
+            st.integers(min_value=min_samples, max_value=max_samples),
+            st.integers(min_value=min_features, max_value=max_features),
+        ),
+        elements=st.floats(
+            min_value=-1e6,
+            max_value=1e6,
+            allow_nan=False,
+            allow_infinity=False,
+        ),
+    )
+
+
+def binary_label_strategy(n_samples: int) -> st.SearchStrategy[np.ndarray]:
+    """Return a strategy that draws a binary label array of fixed length.
+
+    Args:
+        n_samples: Number of labels to generate.
+
+    Returns:
+        A Hypothesis strategy producing ``np.ndarray`` of shape
+        ``(n_samples,)`` with dtype ``int64`` containing only 0 or 1.
+    """
+    return np_st.arrays(
+        dtype=np.int64,
+        shape=(n_samples,),
+        elements=st.integers(min_value=0, max_value=1),
+    )
+
+
+def multiclass_label_strategy(
+    n_samples: int,
+    n_classes: int = 3,
+) -> st.SearchStrategy[np.ndarray]:
+    """Return a strategy that draws a multi-class label array of fixed length.
+
+    Args:
+        n_samples: Number of labels to generate.
+        n_classes: Number of distinct class values (labels in ``[0, n_classes)``).
+
+    Returns:
+        A Hypothesis strategy producing ``np.ndarray`` of shape
+        ``(n_samples,)`` with dtype ``int64``.
+    """
+    return np_st.arrays(
+        dtype=np.int64,
+        shape=(n_samples,),
+        elements=st.integers(min_value=0, max_value=max(0, n_classes - 1)),
+    )
+
+
+def probability_output_strategy(
+    n_samples: int,
+    n_classes: int = 2,
+) -> st.SearchStrategy[np.ndarray]:
+    """Return a strategy that draws a probability output matrix.
+
+    Each row sums to 1.0 (simulating softmax output).
+
+    Args:
+        n_samples: Number of rows (one per sample).
+        n_classes: Number of columns (one per class).
+
+    Returns:
+        A Hypothesis strategy producing ``np.ndarray`` of shape
+        ``(n_samples, n_classes)`` with dtype ``float64`` where each
+        row sums to 1.0.
+    """
+
+    @st.composite
+    def _draw(draw: st.DrawFn) -> np.ndarray:  # type: ignore[type-arg]
+        raw = draw(
+            np_st.arrays(
+                dtype=np.float64,
+                shape=(n_samples, n_classes),
+                elements=st.floats(
+                    min_value=0.0,
+                    max_value=1.0,
+                    allow_nan=False,
+                    allow_infinity=False,
+                ),
+            )
+        )
+        row_sums = raw.sum(axis=1, keepdims=True)
+        # When an entire row is zero, substitute a uniform distribution
+        # so that every row sums to exactly 1.0.
+        zero_rows = (row_sums == 0.0).squeeze(axis=1)
+        if zero_rows.any():
+            raw[zero_rows] = 1.0 / n_classes
+            row_sums = raw.sum(axis=1, keepdims=True)
+        return (raw / row_sums).astype(np.float64)
+
+    return _draw()
+
+
+def scalar_score_strategy(
+    min_value: float = 0.0,
+    max_value: float = 1.0,
+) -> st.SearchStrategy[float]:
+    """Return a strategy that draws a single finite scalar score.
+
+    Args:
+        min_value: Minimum allowed score value.
+        max_value: Maximum allowed score value.
+
+    Returns:
+        A Hypothesis strategy producing a ``float`` in
+        ``[min_value, max_value]``.
+    """
+    return st.floats(
+        min_value=min_value,
+        max_value=max_value,
+        allow_nan=False,
+        allow_infinity=False,
+    )

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,0 +1,11 @@
+# API Reference
+
+Welcome to the AstroML API reference documentation. This section provides detailed documentation for all public modules, classes, and functions within the AstroML package.
+
+## Modules
+
+- Core Modules
+- Integrations
+- Utilities
+
+(Automated API documentation will be injected here)

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,0 +1,26 @@
+site_name: AstroML Documentation
+site_description: Documentation for AstroML including API, Models, and Pipelines
+site_author: AstroML Team
+
+theme:
+  name: material
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.expand
+    - search.suggest
+    - search.highlight
+
+plugins:
+  - search
+
+nav:
+  - Home: index.md
+  - API Reference: api/index.md
+  - Model Cards: models/index.md
+  - Pipelines: pipelines/index.md
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences

--- a/docs/models/index.md
+++ b/docs/models/index.md
@@ -1,0 +1,7 @@
+# Model Cards
+
+This section contains automated model cards for all registered AstroML models. A model card provides detailed information about a model's architecture, training data, performance metrics, and ethical considerations.
+
+## Available Models
+
+(Automated model cards will be generated and listed here)

--- a/docs/pipelines/index.md
+++ b/docs/pipelines/index.md
@@ -1,0 +1,7 @@
+# Pipelines Documentation
+
+Welcome to the pipelines documentation. This section describes the standard training, evaluation, and deployment pipelines used in AstroML.
+
+## Active Pipelines
+
+(Automated pipeline documentation will be generated and listed here)

--- a/monitoring/grafana/dashboards/infrastructure-cost.json
+++ b/monitoring/grafana/dashboards/infrastructure-cost.json
@@ -1,0 +1,175 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calc": "mean",
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "8.4.3",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(rate(node_cpu_seconds_total{mode!=\"idle\"}[5m])) * 100",
+          "interval": "",
+          "legendFormat": "CPU Utilization",
+          "refId": "A"
+        }
+      ],
+      "title": "CPU Utilization - ML Workloads",
+      "type": "stat"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "Cost ($)",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(ml_workload_cost_total) by (instance_type)",
+          "interval": "",
+          "legendFormat": "{{instance_type}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Cost Allocation by Workload",
+      "type": "timeseries"
+    }
+  ],
+  "schemaVersion": 35,
+  "style": "dark",
+  "tags": ["ml", "cost", "optimization"],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "ML Infrastructure Cost Optimization",
+  "uid": "ml-infra-cost",
+  "version": 1
+}

--- a/tests/infrastructure/__init__.py
+++ b/tests/infrastructure/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for infrastructure cost optimization."""

--- a/tests/infrastructure/test_cost_optimization.py
+++ b/tests/infrastructure/test_cost_optimization.py
@@ -1,0 +1,125 @@
+import pytest
+from astroml.infrastructure.cost_optimizer import CostOptimizer, CostAllocation
+from astroml.infrastructure.recommendations import RecommendationEngine
+from astroml.infrastructure.resource_analyzer import ResourceAnalyzer, ResourceMetrics, WorkloadResourceProfile
+
+
+@pytest.fixture
+def resource_analyzer():
+    return ResourceAnalyzer()
+
+
+@pytest.fixture
+def cost_optimizer():
+    return CostOptimizer()
+
+
+@pytest.fixture
+def recommendation_engine(resource_analyzer):
+    return RecommendationEngine(resource_analyzer)
+
+
+@pytest.fixture
+def mock_profiles():
+    return [
+        WorkloadResourceProfile(
+            workload_id="test-batch-1",
+            workload_type="batch",
+            metrics=ResourceMetrics(cpu_utilization_percent=50.0, memory_utilization_percent=60.0),
+            instance_type="ml.c5.xlarge",
+            duration_seconds=7200,
+        ),
+        WorkloadResourceProfile(
+            workload_id="test-inference-1",
+            workload_type="inference",
+            metrics=ResourceMetrics(cpu_utilization_percent=10.0, memory_utilization_percent=15.0),
+            instance_type="ml.m5.large",
+            duration_seconds=36000,
+        ),
+        WorkloadResourceProfile(
+            workload_id="test-idle-1",
+            workload_type="training",
+            metrics=ResourceMetrics(cpu_utilization_percent=5.0, memory_utilization_percent=5.0, gpu_utilization_percent=0.0),
+            instance_type="ml.p3.2xlarge",
+            duration_seconds=18000,
+        ),
+        WorkloadResourceProfile(
+            workload_id="test-gpu-1",
+            workload_type="training",
+            metrics=ResourceMetrics(cpu_utilization_percent=80.0, memory_utilization_percent=85.0, gpu_utilization_percent=90.0),
+            instance_type="ml.p3.2xlarge",
+            duration_seconds=7200,
+        )
+    ]
+
+
+def test_resource_analyzer_scores(resource_analyzer, mock_profiles):
+    scores = resource_analyzer.analyze_utilization(mock_profiles[3])
+    assert scores["cpu_score"] == 0.8
+    assert scores["memory_score"] == 0.85
+    assert scores["gpu_score"] == 0.9
+
+    scores_no_gpu = resource_analyzer.analyze_utilization(mock_profiles[0])
+    assert "gpu_score" not in scores_no_gpu
+    assert scores_no_gpu["cpu_score"] == 0.5
+
+
+def test_resource_analyzer_underutilized(resource_analyzer, mock_profiles):
+    underutilized = resource_analyzer.identify_underutilized_resources(mock_profiles, threshold=0.2)
+    assert len(underutilized) == 2
+    assert underutilized[0].workload_id == "test-inference-1"
+    assert underutilized[1].workload_id == "test-idle-1"
+
+
+def test_cost_optimizer(cost_optimizer, mock_profiles):
+    allocations = cost_optimizer.build_cost_allocation(mock_profiles)
+    assert len(allocations) == 4
+    
+    batch_alloc = allocations["test-batch-1"]
+    assert batch_alloc.duration_hours == 2.0
+    assert batch_alloc.hourly_rate == 0.204
+    assert batch_alloc.total_cost == 0.408
+
+    total = cost_optimizer.calculate_total_cost(allocations)
+    assert total > 0
+
+
+def test_recommendation_engine_spot(recommendation_engine, cost_optimizer, mock_profiles):
+    allocations = cost_optimizer.build_cost_allocation(mock_profiles)
+    rec = recommendation_engine.add_spot_instance_recommendation(mock_profiles[0], allocations["test-batch-1"])
+    assert rec is not None
+    assert rec.recommendation_type == "spot_instance"
+    assert "save up to 70%" in rec.description
+
+
+def test_recommendation_engine_auto_scaling(recommendation_engine, cost_optimizer, mock_profiles):
+    allocations = cost_optimizer.build_cost_allocation(mock_profiles)
+    rec = recommendation_engine.implement_auto_scaling_optimization(mock_profiles[1], allocations["test-inference-1"])
+    assert rec is not None
+    assert rec.recommendation_type == "auto_scaling"
+    assert "auto-scaling" in rec.description
+
+    # High utilization inference should not get recommendation
+    high_util_profile = WorkloadResourceProfile(
+        workload_id="test-inference-2",
+        workload_type="inference",
+        metrics=ResourceMetrics(cpu_utilization_percent=80.0, memory_utilization_percent=80.0),
+        instance_type="ml.m5.large",
+        duration_seconds=36000,
+    )
+    high_util_alloc = cost_optimizer.calculate_workload_cost(high_util_profile)
+    assert recommendation_engine.implement_auto_scaling_optimization(high_util_profile, high_util_alloc) is None
+
+
+def test_recommendation_engine_right_sizing(recommendation_engine, cost_optimizer, mock_profiles):
+    allocations = cost_optimizer.build_cost_allocation(mock_profiles)
+    rec = recommendation_engine.add_savings_opportunity_identification(mock_profiles[2], allocations["test-idle-1"])
+    assert rec is not None
+    assert rec.recommendation_type == "right_sizing"
+    assert "Downsize instance" in rec.description
+
+
+def test_generate_all_recommendations(recommendation_engine, cost_optimizer, mock_profiles):
+    allocations = cost_optimizer.build_cost_allocation(mock_profiles)
+    recs = recommendation_engine.generate_all_recommendations(mock_profiles, allocations)
+    assert len(recs) == 3  # batch gets spot, inference gets auto_scale, idle gets right_sizing

--- a/tests/testing/__init__.py
+++ b/tests/testing/__init__.py
@@ -1,0 +1,1 @@
+# intentionally empty

--- a/tests/testing/test_property_based.py
+++ b/tests/testing/test_property_based.py
@@ -1,0 +1,572 @@
+"""Property-based tests for ML model testing infrastructure.
+
+Issue #658: Validates the four modules in
+``astroml/testing/property_based/`` against realistic ML data produced by
+Hypothesis strategies.
+
+Coverage targets (>90% for changed code):
+- strategies.py
+- model_properties.py
+- data_properties.py
+- invariant_checker.py
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from hypothesis import HealthCheck, Phase, given, settings
+from hypothesis import strategies as st
+from hypothesis.extra import numpy as np_st
+
+from astroml.testing.property_based.data_properties import (
+    DataPropertyValidator,
+    check_class_labels_in_range,
+    check_feature_matrix_shape,
+    check_feature_variance,
+    check_label_array_shape,
+    check_minimum_samples,
+    check_no_nan_or_inf,
+)
+from astroml.testing.property_based.invariant_checker import (
+    InvariantChecker,
+    InvariantViolation,
+    create_standard_invariant_checker,
+)
+from astroml.testing.property_based.model_properties import (
+    BUILTIN_PROPERTIES,
+    ModelPropertyRunner,
+    PropertyCheckResult,
+    binary_predictions_in_set,
+    outputs_are_finite,
+    output_shape_matches_samples,
+    probability_rows_sum_to_one,
+    scores_in_unit_interval,
+)
+from astroml.testing.property_based.strategies import (
+    binary_label_strategy,
+    feature_matrix_strategy,
+    multiclass_label_strategy,
+    probability_output_strategy,
+    scalar_score_strategy,
+)
+
+
+# ── Shared Hypothesis settings ────────────────────────────────────────────────
+
+_SETTINGS = settings(
+    max_examples=50,
+    deadline=None,
+    phases=[Phase.generate, Phase.shrink],
+    suppress_health_check=[HealthCheck.too_slow],
+)
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 1. strategies.py
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestFeatureMatrixStrategy:
+    """Tests for :func:`feature_matrix_strategy`."""
+
+    @given(
+        X=feature_matrix_strategy(
+            min_samples=1, max_samples=20, min_features=2, max_features=10
+        )
+    )
+    @_SETTINGS
+    def test_shape_within_bounds(self, X: np.ndarray) -> None:
+        assert X.ndim == 2
+        assert 1 <= X.shape[0] <= 20
+        assert 2 <= X.shape[1] <= 10
+
+    @given(X=feature_matrix_strategy())
+    @_SETTINGS
+    def test_dtype_is_float32(self, X: np.ndarray) -> None:
+        assert X.dtype == np.float32
+
+    @given(X=feature_matrix_strategy())
+    @_SETTINGS
+    def test_all_finite(self, X: np.ndarray) -> None:
+        assert np.all(np.isfinite(X))
+
+
+class TestLabelStrategies:
+    """Tests for binary / multiclass label strategies."""
+
+    @given(y=binary_label_strategy(n_samples=10))
+    @_SETTINGS
+    def test_binary_labels_shape(self, y: np.ndarray) -> None:
+        assert y.shape == (10,)
+        assert np.all(np.isin(y, [0, 1]))
+
+    @given(y=multiclass_label_strategy(n_samples=15, n_classes=4))
+    @_SETTINGS
+    def test_multiclass_labels_in_range(self, y: np.ndarray) -> None:
+        assert y.shape == (15,)
+        assert np.all((y >= 0) & (y < 4))
+
+
+class TestProbabilityOutputStrategy:
+    """Tests for :func:`probability_output_strategy`."""
+
+    @given(probs=probability_output_strategy(n_samples=5, n_classes=3))
+    @_SETTINGS
+    def test_rows_sum_to_one(self, probs: np.ndarray) -> None:
+        assert probs.shape == (5, 3)
+        assert np.all(np.abs(probs.sum(axis=1) - 1.0) < 1e-9)
+
+    @given(probs=probability_output_strategy(n_samples=8, n_classes=2))
+    @_SETTINGS
+    def test_values_non_negative(self, probs: np.ndarray) -> None:
+        assert np.all(probs >= 0.0)
+
+
+class TestScalarScoreStrategy:
+    """Tests for :func:`scalar_score_strategy`."""
+
+    @given(score=scalar_score_strategy())
+    @_SETTINGS
+    def test_score_in_unit_interval(self, score: float) -> None:
+        assert 0.0 <= score <= 1.0
+
+    @given(score=scalar_score_strategy(min_value=-5.0, max_value=5.0))
+    @_SETTINGS
+    def test_custom_bounds(self, score: float) -> None:
+        assert -5.0 <= score <= 5.0
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 2. model_properties.py — built-in invariants
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestBuiltinProperties:
+    """Unit tests for the built-in property functions."""
+
+    def test_outputs_are_finite_passes(self) -> None:
+        X = np.zeros((3, 2), dtype=np.float32)
+        output = np.array([0.1, 0.5, 0.9])
+        assert outputs_are_finite(X, output) is True
+
+    def test_outputs_are_finite_fails_on_nan(self) -> None:
+        X = np.zeros((2, 2), dtype=np.float32)
+        output = np.array([0.5, float("nan")])
+        assert outputs_are_finite(X, output) is False
+
+    def test_outputs_are_finite_fails_on_inf(self) -> None:
+        X = np.zeros((2, 2), dtype=np.float32)
+        output = np.array([float("inf"), 0.3])
+        assert outputs_are_finite(X, output) is False
+
+    def test_output_shape_matches_samples_pass(self) -> None:
+        X = np.zeros((5, 3), dtype=np.float32)
+        output = np.zeros((5, 2))
+        assert output_shape_matches_samples(X, output) is True
+
+    def test_output_shape_matches_samples_fail(self) -> None:
+        X = np.zeros((5, 3), dtype=np.float32)
+        output = np.zeros((4, 2))
+        assert output_shape_matches_samples(X, output) is False
+
+    def test_binary_predictions_in_set_pass(self) -> None:
+        X = np.zeros((4, 2), dtype=np.float32)
+        output = np.array([0, 1, 0, 1])
+        assert binary_predictions_in_set(X, output) is True
+
+    def test_binary_predictions_in_set_fail(self) -> None:
+        X = np.zeros((3, 2), dtype=np.float32)
+        output = np.array([0, 1, 2])
+        assert binary_predictions_in_set(X, output) is False
+
+    def test_probability_rows_sum_to_one_pass(self) -> None:
+        X = np.zeros((2, 2), dtype=np.float32)
+        output = np.array([[0.3, 0.7], [0.5, 0.5]])
+        assert probability_rows_sum_to_one(X, output) is True
+
+    def test_probability_rows_sum_to_one_fails_1d(self) -> None:
+        X = np.zeros((2, 2), dtype=np.float32)
+        output = np.array([0.5, 0.5])
+        assert probability_rows_sum_to_one(X, output) is False
+
+    def test_probability_rows_sum_to_one_fails_wrong_sum(self) -> None:
+        X = np.zeros((1, 2), dtype=np.float32)
+        output = np.array([[0.4, 0.4]])  # sums to 0.8
+        assert probability_rows_sum_to_one(X, output) is False
+
+    def test_scores_in_unit_interval_pass(self) -> None:
+        X = np.zeros((3, 2), dtype=np.float32)
+        output = np.array([0.0, 0.5, 1.0])
+        assert scores_in_unit_interval(X, output) is True
+
+    def test_scores_in_unit_interval_fail(self) -> None:
+        X = np.zeros((2, 2), dtype=np.float32)
+        output = np.array([0.5, 1.5])
+        assert scores_in_unit_interval(X, output) is False
+
+    def test_builtin_registry_completeness(self) -> None:
+        expected = {
+            "outputs_are_finite",
+            "output_shape_matches_samples",
+            "binary_predictions_in_set",
+            "probability_rows_sum_to_one",
+            "scores_in_unit_interval",
+        }
+        assert set(BUILTIN_PROPERTIES.keys()) == expected
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 3. model_properties.py — ModelPropertyRunner
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestModelPropertyRunner:
+    """Integration tests for :class:`ModelPropertyRunner`."""
+
+    def _identity_model(self, X: np.ndarray) -> np.ndarray:
+        """Model that returns a column of zeros—always finite, shape-correct."""
+        return np.zeros(X.shape[0], dtype=np.float32)
+
+    def _nan_model(self, X: np.ndarray) -> np.ndarray:
+        """Model that always injects NaN."""
+        out = np.zeros(X.shape[0], dtype=np.float32)
+        out[0] = float("nan")
+        return out
+
+    def test_runner_passes_for_valid_model(self) -> None:
+        runner = ModelPropertyRunner(
+            model=self._identity_model,
+            properties=[outputs_are_finite, output_shape_matches_samples],
+            n_features=4,
+        )
+        results = runner.run(max_examples=20)
+        assert len(results) == 2
+        assert all(r.passed for r in results)
+
+    def test_runner_detects_nan_output(self) -> None:
+        runner = ModelPropertyRunner(
+            model=self._nan_model,
+            properties=[outputs_are_finite],
+            n_features=4,
+        )
+        results = runner.run(max_examples=10)
+        assert len(results) == 1
+        assert results[0].passed is False
+        assert results[0].property_name == "outputs_are_finite"
+
+    def test_runner_results_property(self) -> None:
+        runner = ModelPropertyRunner(
+            model=self._identity_model,
+            properties=[outputs_are_finite],
+            n_features=3,
+        )
+        runner.run(max_examples=5)
+        assert len(runner.results) == 1
+
+    def test_property_check_result_fields(self) -> None:
+        result = PropertyCheckResult(property_name="test_prop", passed=True)
+        assert result.property_name == "test_prop"
+        assert result.passed is True
+        assert result.violation_input is None
+        assert result.error_message is None
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 4. data_properties.py — individual checks
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestDataPropertyChecks:
+    """Unit tests for individual data validation functions."""
+
+    # check_no_nan_or_inf
+    def test_no_nan_or_inf_pass(self) -> None:
+        X = np.array([[1.0, 2.0], [3.0, 4.0]])
+        result = check_no_nan_or_inf(X)
+        assert result.passed is True
+
+    def test_no_nan_or_inf_fail_nan(self) -> None:
+        X = np.array([[1.0, float("nan")]])
+        result = check_no_nan_or_inf(X)
+        assert result.passed is False
+        assert "NaN" in result.error_message  # type: ignore[operator]
+
+    def test_no_nan_or_inf_fail_inf(self) -> None:
+        X = np.array([[float("inf"), 1.0]])
+        result = check_no_nan_or_inf(X)
+        assert result.passed is False
+
+    # check_feature_matrix_shape
+    def test_feature_matrix_shape_pass(self) -> None:
+        X = np.zeros((10, 5))
+        result = check_feature_matrix_shape(X, expected_features=5)
+        assert result.passed is True
+
+    def test_feature_matrix_shape_fail_wrong_dim(self) -> None:
+        X = np.zeros((10,))
+        result = check_feature_matrix_shape(X)
+        assert result.passed is False
+
+    def test_feature_matrix_shape_fail_wrong_features(self) -> None:
+        X = np.zeros((10, 4))
+        result = check_feature_matrix_shape(X, expected_features=5)
+        assert result.passed is False
+
+    # check_label_array_shape
+    def test_label_array_shape_pass(self) -> None:
+        X = np.zeros((5, 3))
+        y = np.array([0, 1, 0, 1, 0])
+        result = check_label_array_shape(y, X)
+        assert result.passed is True
+
+    def test_label_array_shape_fail_mismatch(self) -> None:
+        X = np.zeros((5, 3))
+        y = np.array([0, 1])
+        result = check_label_array_shape(y, X)
+        assert result.passed is False
+
+    def test_label_array_shape_fail_2d(self) -> None:
+        X = np.zeros((3, 3))
+        y = np.zeros((3, 2))
+        result = check_label_array_shape(y, X)
+        assert result.passed is False
+
+    # check_class_labels_in_range
+    def test_class_labels_in_range_pass(self) -> None:
+        y = np.array([0, 1, 2, 0])
+        result = check_class_labels_in_range(y, n_classes=3)
+        assert result.passed is True
+
+    def test_class_labels_in_range_fail_negative(self) -> None:
+        y = np.array([-1, 0, 1])
+        result = check_class_labels_in_range(y, n_classes=2)
+        assert result.passed is False
+
+    def test_class_labels_in_range_fail_too_large(self) -> None:
+        y = np.array([0, 1, 5])
+        result = check_class_labels_in_range(y, n_classes=3)
+        assert result.passed is False
+
+    # check_minimum_samples
+    def test_minimum_samples_pass(self) -> None:
+        X = np.zeros((10, 3))
+        result = check_minimum_samples(X, min_samples=5)
+        assert result.passed is True
+
+    def test_minimum_samples_fail(self) -> None:
+        X = np.zeros((2, 3))
+        result = check_minimum_samples(X, min_samples=5)
+        assert result.passed is False
+
+    # check_feature_variance
+    def test_feature_variance_pass(self) -> None:
+        X = np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
+        result = check_feature_variance(X, min_variance=0.0)
+        assert result.passed is True
+
+    def test_feature_variance_fail_constant_column(self) -> None:
+        X = np.array([[1.0, 5.0], [1.0, 6.0], [1.0, 7.0]])
+        result = check_feature_variance(X, min_variance=0.0)
+        assert result.passed is False
+        assert "0" in result.error_message  # type: ignore[operator]
+
+    def test_feature_variance_single_sample_skipped(self) -> None:
+        X = np.array([[1.0, 1.0]])
+        result = check_feature_variance(X)
+        assert result.passed is True
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 5. data_properties.py — DataPropertyValidator
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestDataPropertyValidator:
+    """Tests for :class:`DataPropertyValidator`."""
+
+    def test_all_passed_on_clean_data(self) -> None:
+        validator = DataPropertyValidator(expected_features=3, n_classes=2)
+        X = np.random.randn(20, 3).astype(np.float32)
+        y = np.array([0, 1] * 10, dtype=np.int64)
+        assert validator.all_passed(X, y) is True
+
+    def test_fails_on_nan(self) -> None:
+        validator = DataPropertyValidator()
+        X = np.array([[1.0, float("nan")], [2.0, 3.0]])
+        results = validator.validate(X)
+        failed = [r for r in results if not r.passed]
+        assert any(r.check_name == "no_nan_or_inf" for r in failed)
+
+    def test_validate_without_labels(self) -> None:
+        validator = DataPropertyValidator(expected_features=2)
+        X = np.array([[1.0, 2.0], [3.0, 4.0]])
+        results = validator.validate(X)
+        assert all(r.passed for r in results)
+
+    def test_validate_wrong_feature_count(self) -> None:
+        validator = DataPropertyValidator(expected_features=5)
+        X = np.zeros((10, 3))
+        results = validator.validate(X)
+        failed_names = [r.check_name for r in results if not r.passed]
+        assert "feature_matrix_shape" in failed_names
+
+    def test_all_passed_returns_false_on_bad_data(self) -> None:
+        validator = DataPropertyValidator(min_samples=100)
+        X = np.zeros((5, 3))
+        assert validator.all_passed(X) is False
+
+    @given(
+        X=feature_matrix_strategy(
+            min_samples=2, max_samples=30, min_features=3, max_features=3
+        )
+    )
+    @_SETTINGS
+    def test_hypothesis_clean_matrix_passes(self, X: np.ndarray) -> None:
+        validator = DataPropertyValidator(expected_features=3)
+        results = validator.validate(X)
+        # feature_variance may legitimately fail for constant matrices generated
+        # by the strategy (all-zeros); that check is unit-tested separately.
+        for r in results:
+            if r.check_name == "feature_variance":
+                continue
+            assert r.passed, f"Check '{r.check_name}' failed: {r.error_message}"
+
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# 6. invariant_checker.py — InvariantChecker
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+class TestInvariantChecker:
+    """Tests for :class:`InvariantChecker`."""
+
+    def _make_checker(self) -> InvariantChecker:
+        checker = InvariantChecker()
+        checker.register(
+            "finite", lambda X, y: bool(np.all(np.isfinite(y)))
+        )
+        return checker
+
+    def test_check_passes_for_finite_output(self) -> None:
+        checker = self._make_checker()
+        X = np.zeros((3, 2))
+        output = np.array([0.1, 0.5, 0.9])
+        violations = checker.check(X, output)
+        assert violations == []
+
+    def test_check_detects_nan_output(self) -> None:
+        checker = self._make_checker()
+        X = np.zeros((2, 2))
+        output = np.array([0.5, float("nan")])
+        violations = checker.check(X, output)
+        assert len(violations) == 1
+        assert violations[0].invariant_name == "finite"
+
+    def test_register_duplicate_raises(self) -> None:
+        checker = self._make_checker()
+        with pytest.raises(ValueError, match="already registered"):
+            checker.register("finite", lambda X, y: True)
+
+    def test_remove_invariant(self) -> None:
+        checker = self._make_checker()
+        checker.remove("finite")
+        assert "finite" not in checker.registered_names
+
+    def test_remove_missing_raises(self) -> None:
+        checker = InvariantChecker()
+        with pytest.raises(KeyError):
+            checker.remove("nonexistent")
+
+    def test_registered_names_property(self) -> None:
+        checker = self._make_checker()
+        assert "finite" in checker.registered_names
+
+    def test_violations_property_after_check(self) -> None:
+        checker = self._make_checker()
+        X = np.zeros((1, 2))
+        output = np.array([float("nan")])
+        checker.check(X, output)
+        assert len(checker.violations) == 1
+
+    def test_check_per_sample_sets_index(self) -> None:
+        checker = InvariantChecker()
+        checker.register(
+            "non_negative", lambda X, y: bool(np.all(y >= 0))
+        )
+        X = np.zeros((3, 2))
+        output = np.array([1.0, -1.0, 2.0])
+        violations = checker.check_per_sample(X, output)
+        assert len(violations) == 1
+        assert violations[0].sample_index == 1
+
+    def test_invariant_violation_fields(self) -> None:
+        X = np.zeros((1, 2))
+        output = np.array([0.5])
+        v = InvariantViolation(
+            invariant_name="my_inv",
+            sample_index=0,
+            input_sample=X,
+            model_output=output,
+            description="test violation",
+        )
+        assert v.invariant_name == "my_inv"
+        assert v.sample_index == 0
+        assert v.description == "test violation"
+
+    def test_exception_in_invariant_is_captured(self) -> None:
+        checker = InvariantChecker()
+
+        def boom(X: np.ndarray, y: np.ndarray) -> bool:
+            raise RuntimeError("deliberate failure")
+
+        checker.register("boom", boom)
+        X = np.zeros((2, 2))
+        output = np.zeros(2)
+        violations = checker.check(X, output)
+        assert len(violations) == 1
+        assert "deliberate failure" in violations[0].description
+
+
+class TestStandardInvariantChecker:
+    """Tests for :func:`create_standard_invariant_checker`."""
+
+    def test_factory_registers_expected_invariants(self) -> None:
+        checker = create_standard_invariant_checker()
+        assert "finite_outputs" in checker.registered_names
+        assert "non_negative_probabilities" in checker.registered_names
+        assert "output_shape_consistent" in checker.registered_names
+
+    def test_standard_checker_passes_valid_output(self) -> None:
+        checker = create_standard_invariant_checker()
+        X = np.zeros((5, 4))
+        output = np.full((5, 2), 0.5)
+        violations = checker.check(X, output)
+        assert violations == []
+
+    def test_standard_checker_fails_inf_output(self) -> None:
+        checker = create_standard_invariant_checker()
+        X = np.zeros((2, 4))
+        output = np.array([[float("inf"), 0.0], [0.5, 0.5]])
+        violations = checker.check(X, output)
+        assert any(v.invariant_name == "finite_outputs" for v in violations)
+
+    def test_standard_checker_fails_wrong_shape(self) -> None:
+        checker = create_standard_invariant_checker()
+        X = np.zeros((3, 4))
+        output = np.zeros((2, 2))
+        violations = checker.check(X, output)
+        assert any(v.invariant_name == "output_shape_consistent" for v in violations)
+
+    @given(
+        X=feature_matrix_strategy(
+            min_samples=1, max_samples=20, min_features=4, max_features=4
+        )
+    )
+    @_SETTINGS
+    def test_hypothesis_zero_output_passes(self, X: np.ndarray) -> None:
+        checker = create_standard_invariant_checker()
+        output = np.zeros((X.shape[0], 2), dtype=np.float64)
+        violations = checker.check(X, output)
+        assert violations == [], f"Unexpected violations: {violations}"


### PR DESCRIPTION
Closes #658 

## feat: Add automated model testing with property-based testing (#658)

### Summary

Implements property-based testing for ML models using the Hypothesis
framework. Four new modules are added under a new
`astroml/testing/property_based/` package, along with a full test suite
in `tests/testing/test_property_based.py`.

---

### Changes

#### `astroml/testing/property_based/strategies.py` *(new)*
Reusable Hypothesis strategies for generating realistic ML inputs:
- `feature_matrix_strategy` — float32 2-D arrays within configurable bounds
- `binary_label_strategy` / `multiclass_label_strategy` — integer label arrays
- `probability_output_strategy` — row-normalised probability matrices (each row sums to 1.0)
- `scalar_score_strategy` — finite scalar scores in a configurable range

#### `astroml/testing/property_based/model_properties.py` *(new)*
Model invariant definitions and property-based test runner:
- Five built-in invariant functions: `outputs_are_finite`, `output_shape_matches_samples`, `binary_predictions_in_set`, `probability_rows_sum_to_one`, `scores_in_unit_interval`
- `BUILTIN_PROPERTIES` registry dict
- `ModelPropertyRunner` dataclass — wires properties with Hypothesis and returns structured `PropertyCheckResult` instances without
