### PR TITLE
ci: enforce public API docstring coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Check naming conventions with ruff
         run: ruff check --select N --ignore N803,N805,N806,N812,N815 astroml api
 
+      - name: Check public API docstring coverage
+        run: interrogate astroml api tests
+
       - name: Check code complexity with xenon
         run: xenon --max-absolute C --max-modules D --max-average C astroml/
       - name: Check function complexity

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,8 +19,19 @@ repos:
         args: [--baseline, .secrets.baseline]
         exclude: package.lock.json|go.sum|pnpm-lock.yaml|yarn.lock|poetry.lock
 
-  - repo: https://github.com/rubik/radon
-    rev: 6.0.1
+  - repo: local
     hooks:
       - id: radon
+        name: Check code complexity with Radon
+        entry: radon
+        language: python
+        additional_dependencies: ["radon==6.0.1"]
         args: ["cc", "-nc", "-s", "-i"]
+
+      - id: docstring-coverage
+        name: Check public API docstring coverage
+        entry: interrogate
+        language: python
+        additional_dependencies: ["interrogate>=1.7.0,<2.0"]
+        args: ["astroml", "api", "tests"]
+        pass_filenames: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,4 +30,6 @@ Use built-in parameterized generics where possible (`dict[str, Any]`, `list[str]
 ## Style
 
 - Run `black`, `ruff`, and type checks before submitting.
+- Document public classes, methods, and functions. Run `make lint-docs` to
+  enforce the repository's docstring coverage floor before submitting.
 - Keep functions small and testable.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help quickstart test test-api lint format clean install run-api canary-deploy canary-promote rollback-llm dependency-tree llm-test llm-eval llm-cost-check llm-validate-prompts llm-safety-scan security-audit secrets-scan complexity
+.PHONY: help quickstart test test-api lint lint-docs format clean install run-api canary-deploy canary-promote rollback-llm dependency-tree llm-test llm-eval llm-cost-check llm-validate-prompts llm-safety-scan security-audit secrets-scan complexity
 
 help:
 	@echo "AstroML Development Commands"
@@ -9,6 +9,7 @@ help:
 	@echo "make test                Run full test suite"
 	@echo "make test-api            Run API integration tests only"
 	@echo "make lint                Run linters (ruff, mypy)"
+	@echo "make lint-docs           Enforce public API docstring coverage"
 	@echo "make format              Format code (black, isort)"
 	@echo "make format-check        Check formatting without modifying files"
 	@echo "make complexity          Run code complexity analysis (xenon)"
@@ -44,6 +45,9 @@ test-api:
 lint:
 	ruff check astroml/ tests/ api/
 	mypy astroml/ --ignore-missing-imports
+
+lint-docs:
+	interrogate astroml/ api/ tests/
 
 format:
 	black astroml/ tests/ api/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ structural = "astroml.features.structural_importance"
 [project.optional-dependencies]
 gpu = ["torch>=2.0.0", "torch-geometric>=2.3.0"]
 viz = ["matplotlib>=3.7.0", "seaborn>=0.12.0"]
-dev = ["pytest>=7.4.0", "black>=23.11.0", "mypy>=1.7.0", "ruff>=0.4.0", "pytest-asyncio>=0.23", "pytest-cov>=4.1.0", "pytest-mock>=3.12.0", "hypothesis>=6.100.0", "flake8>=6.1.0", "pre-commit>=3.7.0", "isort>=5.13.0", "radon>=6.0.1", "xenon>=0.9.1"]
+dev = ["pytest>=7.4.0", "black>=23.11.0", "mypy>=1.7.0", "ruff>=0.4.0", "pytest-asyncio>=0.23", "pytest-cov>=4.1.0", "pytest-mock>=3.12.0", "hypothesis>=6.100.0", "flake8>=6.1.0", "pre-commit>=3.7.0", "isort>=5.13.0", "radon>=6.0.1", "xenon>=0.9.1", "interrogate>=1.7.0,<2.0"]
 notebook = ["jupyter>=1.0.0", "notebook>=7.0.0", "ipykernel>=6.26.0"]
 dask = ["dask[complete]>=2024.1.0"]
 
@@ -75,3 +75,23 @@ exclude_lines = [
 [tool.mypy]
 strict = true
 python_version = "3.10"
+
+[tool.interrogate]
+fail-under = 68.0
+ignore-init-method = true
+ignore-magic = true
+ignore-module = true
+ignore-nested-classes = true
+ignore-nested-functions = true
+ignore-overloaded-functions = true
+ignore-private = true
+ignore-property-decorators = true
+ignore-semiprivate = true
+verbose = 1
+exclude = [
+    # Existing syntax errors prevent AST parsing; remove these exclusions when
+    # their owning issues repair the files.
+    "astroml/llm/labeling/consensus.py",
+    "astroml/models/deep_svdd_trainer.py",
+    "api/routers/query.py",
+]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -27,6 +27,7 @@ mypy>=1.7.0
 ruff>=0.4.0
 isort>=5.13.0
 pre-commit>=3.7.0
+interrogate>=1.7.0,<2.0
 
 # ── Code complexity analysis ─────────────────────────────────────────────
 radon>=6.0.1

--- a/tests/test_docstring_ci.py
+++ b/tests/test_docstring_ci.py
@@ -1,0 +1,28 @@
+"""Tests for the repository-wide docstring validation wiring."""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _read(path: str) -> str:
+    """Return a UTF-8 repository file as text."""
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+def test_interrogate_config_enforces_documentation_baseline() -> None:
+    """Ensure the checked-in configuration keeps the current coverage floor."""
+    pyproject = _read("pyproject.toml")
+
+    assert "[tool.interrogate]" in pyproject
+    assert "fail-under = 68.0" in pyproject
+    assert "ignore-module = true" in pyproject
+
+
+def test_docstring_check_is_available_in_every_developer_workflow() -> None:
+    """Ensure local, pre-commit, and CI workflows all run Interrogate."""
+    assert "interrogate>=1.7.0,<2.0" in _read("requirements-dev.txt")
+    assert "make lint-docs" in _read("CONTRIBUTING.md")
+    assert "interrogate astroml/ api/ tests/" in _read("Makefile")
+    assert "id: docstring-coverage" in _read(".pre-commit-config.yaml")
+    assert "interrogate astroml api tests" in _read(".github/workflows/ci.yml")


### PR DESCRIPTION
Closes #499

## What changed

- add Interrogate to the development dependency sets
- configure a 68% public API docstring coverage floor across `astroml`, `api`, and `tests`
- add the docstring gate to the main CI workflow and pre-commit
- add `make lint-docs` and contributor guidance
- add focused tests that verify the gate remains wired into local, pre-commit, and CI workflows
- repair the existing invalid remote Radon hook by making it a pinned local Python hook, allowing pre-commit to initialize

The 68% threshold captures the current 68.2% baseline and prevents documentation
coverage regressions without requiring an unrelated repository-wide docstring
rewrite. Three pre-existing files with syntax errors are explicitly excluded until
their owning fixes make them AST-parseable.

## Validation

- `python -m interrogate -q astroml api tests` — passed (68.2%, minimum 68.0%)
- `python -m pre_commit run docstring-coverage --all-files` — passed
- `python -m pytest --noconftest tests/test_docstring_ci.py -v` — 2 passed
- `python -m black --check tests/test_docstring_ci.py` — passed
- `python -m ruff check tests/test_docstring_ci.py` — passed
- `git diff --check` — passed

## Local suite note

The normal test collection imports the repository-wide `tests/conftest.py`, which
requires the full ML dependency stack; this checkout currently stops at missing
`scipy`. The focused configuration tests were therefore run with `--noconftest`.
GitHub CI installs `requirements-cpu.txt`, `requirements-api.txt`, and
`requirements-dev.txt` before running the full suite.
