### PR TITLE
refactor: remove unused imports and parameters

### DIFF
--- a/astroml/api/app.py
+++ b/astroml/api/app.py
@@ -42,7 +42,7 @@ _session_factory: async_sessionmaker = async_sessionmaker(_engine, expire_on_com
 
 
 @asynccontextmanager
-async def lifespan(application: FastAPI) -> AsyncGenerator[None, None]:
+async def lifespan(_application: FastAPI) -> AsyncGenerator[None, None]:
     """Start the batch scheduler on startup; stop it cleanly on shutdown."""
     start_scheduler(_session_factory)
     try:

--- a/astroml/benchmarking/utils.py
+++ b/astroml/benchmarking/utils.py
@@ -62,7 +62,7 @@ class Timer:
         self.start_time = time.perf_counter()
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(self, exc_type, _exc_val, _exc_tb):
         self.end_time = time.perf_counter()
         self.elapsed = self.end_time - self.start_time
 
@@ -94,7 +94,7 @@ class MemoryMonitor:
         self.gpu_start = measure_gpu_memory()
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(self, exc_type, _exc_val, _exc_tb):
         self.end_memory = measure_memory_usage()
         self.gpu_end = measure_gpu_memory()
 

--- a/astroml/ci/complexity_check.py
+++ b/astroml/ci/complexity_check.py
@@ -12,8 +12,7 @@ import ast
 import collections
 import sys
 from pathlib import Path
-from typing import Dict, List, Tuple
-
+from typing import List
 
 #: Hard limit — CI will fail if any function exceeds this.
 MAX_COMPLEXITY_HARD: int = 15

--- a/astroml/core/mocks.py
+++ b/astroml/core/mocks.py
@@ -4,6 +4,7 @@ Provides mock implementations of the abstract base classes for use in tests.
 These implementations allow testing without requiring real data sources or
 external dependencies.
 """
+
 from __future__ import annotations
 
 from datetime import datetime
@@ -11,7 +12,7 @@ from typing import Any, Dict, List, Optional
 
 import pandas as pd
 
-from .abstracts import Ingestor, FeatureComputer, GraphBuilder, IngestionResult, ComputationResult, Graph
+from .abstracts import FeatureComputer, Graph, GraphBuilder, IngestionResult, Ingestor
 
 
 class MockIngestor(Ingestor):
@@ -116,10 +117,12 @@ class MockFeatureComputer(FeatureComputer):
             return result
         else:
             # Return a simple mock DataFrame
-            return pd.DataFrame({
-                self.feature_name: [1.0] * 10,
-                "id": list(range(10)),
-            })
+            return pd.DataFrame(
+                {
+                    self.feature_name: [1.0] * 10,
+                    "id": list(range(10)),
+                }
+            )
 
     def get_feature_schema(self) -> Dict[str, Any]:
         """Get mock feature schema.

--- a/astroml/db/models/llm_jobs.py
+++ b/astroml/db/models/llm_jobs.py
@@ -1,11 +1,11 @@
 """SQLAlchemy models for LLM backfill job tracking."""
+
 from __future__ import annotations
 
 from datetime import datetime
 from typing import Optional
 
 from sqlalchemy import (
-    Column,
     DateTime,
     Float,
     ForeignKey,
@@ -46,7 +46,9 @@ class LLMBackfillItem(Base):
     __tablename__ = "llm_backfill_items"
 
     id: Mapped[str] = mapped_column(String(64), primary_key=True)
-    job_id: Mapped[str] = mapped_column(String(64), ForeignKey("llm_backfill_jobs.id"), nullable=False, index=True)
+    job_id: Mapped[str] = mapped_column(
+        String(64), ForeignKey("llm_backfill_jobs.id"), nullable=False, index=True
+    )
     item_ref: Mapped[str] = mapped_column(String(256), nullable=False)
     status: Mapped[str] = mapped_column(String(20), default="pending", index=True)
     retry_count: Mapped[int] = mapped_column(Integer, default=0)

--- a/astroml/db/query_profiler.py
+++ b/astroml/db/query_profiler.py
@@ -88,7 +88,7 @@ class QueryProfiler:
             statement: str,
             parameters: dict[str, Any],
             context: Any,
-            executemany: bool,
+            _executemany: bool,
         ) -> None:
             context._query_start_time = time.perf_counter()
 
@@ -99,7 +99,7 @@ class QueryProfiler:
             statement: str,
             parameters: dict[str, Any],
             context: Any,
-            executemany: bool,
+            _executemany: bool,
         ) -> None:
             if not hasattr(context, "_query_start_time"):
                 return

--- a/astroml/db/unit_of_work.py
+++ b/astroml/db/unit_of_work.py
@@ -60,7 +60,7 @@ class UnitOfWork:
         return self
 
     def __exit__(
-        self, exc_type: type | None, exc_val: Exception | None, exc_tb: object | None
+        self, exc_type: type | None, _exc_val: Exception | None, _exc_tb: object | None
     ) -> None:
         if exc_type is not None:
             self.rollback()

--- a/astroml/features/feature_engine.py
+++ b/astroml/features/feature_engine.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import concurrent.futures
 import logging
 import threading
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 from collections.abc import Callable
 from contextlib import contextmanager
 from dataclasses import dataclass, field
@@ -26,7 +26,7 @@ from typing import (
 import pandas as pd
 
 from ..cache import cached_feature
-from ..core.abstracts import FeatureComputer as CoreFeatureComputer, ComputationResult
+from ..core.abstracts import FeatureComputer as CoreFeatureComputer
 
 logger = logging.getLogger(__name__)
 
@@ -507,9 +507,9 @@ class ComputationEngine:
                                 f"Plugin {ep.name} does not subclass BaseFeatureComputer"
                             )
                     elif callable(plugin_cls):
-                        from .feature_store import FeatureRegistry
-
-                        logger.info(f"Plugin {ep.name} is a callable; register via FeatureRegistry")
+                        logger.info(
+                            f"Plugin {ep.name} is a callable; register via the feature registry"
+                        )
                 except Exception as e:
                     logger.warning(f"Failed to load plugin '{ep.name}': {e}")
         except ImportError:

--- a/astroml/features/feature_store.py
+++ b/astroml/features/feature_store.py
@@ -39,12 +39,9 @@ from collections.abc import Callable
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
-from typing import Any, Callable, Dict, List, Optional, Protocol, Union, runtime_checkable
 from enum import Enum
 from pathlib import Path
-from contextlib import contextmanager
-import concurrent.futures
-import sqlite3
+from typing import Any, Callable, Dict, List, Optional, Protocol, runtime_checkable
 
 import pandas as pd
 from cachetools import TTLCache
@@ -280,8 +277,7 @@ class FeatureStorage:
     def _init_database(self) -> None:
         """Initialize SQLite database with required tables."""
         with sqlite3.connect(self.db_path) as conn:
-            conn.executescript(
-                """
+            conn.executescript("""
                 CREATE TABLE IF NOT EXISTS feature_definitions (
                     feature_id TEXT PRIMARY KEY,
                     name TEXT NOT NULL,
@@ -320,8 +316,7 @@ class FeatureStorage:
                 
                 CREATE INDEX IF NOT EXISTS idx_feature_definitions_status 
                     ON feature_definitions(status);
-            """
-            )
+            """)
 
     def store_feature_definition(self, feature_def: FeatureDefinition) -> None:
         """Store feature definition in database.
@@ -352,7 +347,7 @@ class FeatureStorage:
                     json.dumps(feature_def.metadata),
                 ),
             )
-    
+
     @staticmethod
     def _row_to_dict(row: tuple[Any, ...], columns: List[str]) -> Dict[str, Any]:
         """Map a SQLite row to a dictionary using column names."""
@@ -366,16 +361,25 @@ class FeatureStorage:
     def _deserialize_feature_definition(row: tuple[Any, ...]) -> FeatureDefinition:
         """Deserialize a feature definition row into a dataclass."""
         columns = [
-            "feature_id", "name", "version", "description", "feature_type",
-            "parameters", "tags", "owner", "status", "created_at",
-            "updated_at", "metadata",
+            "feature_id",
+            "name",
+            "version",
+            "description",
+            "feature_type",
+            "parameters",
+            "tags",
+            "owner",
+            "status",
+            "created_at",
+            "updated_at",
+            "metadata",
         ]
         data = FeatureStorage._row_to_dict(row, columns)
         data.pop("feature_id", None)
         data["created_at"] = datetime.fromisoformat(data["created_at"])
         data["updated_at"] = datetime.fromisoformat(data["updated_at"])
         return FeatureDefinition.from_dict(data)
-    
+
     def get_feature_definition(self, feature_id: str) -> Optional[FeatureDefinition]:
         """Retrieve feature definition by ID.
 
@@ -414,7 +418,7 @@ class FeatureStorage:
         """
         query = "SELECT * FROM feature_definitions WHERE 1=1"
         params: List[Any] = []
-        
+
         if status:
             query += " AND status = ?"
             params.append(status.value)
@@ -426,16 +430,25 @@ class FeatureStorage:
         with sqlite3.connect(self.db_path) as conn:
             cursor = conn.execute(query, params)
             rows = cursor.fetchall()
-            
+
             features: List[FeatureDefinition] = []
             columns = [
-                "feature_id", "name", "version", "description", "feature_type",
-                "parameters", "tags", "owner", "status", "created_at", 
-                "updated_at", "metadata"
+                "feature_id",
+                "name",
+                "version",
+                "description",
+                "feature_type",
+                "parameters",
+                "tags",
+                "owner",
+                "status",
+                "created_at",
+                "updated_at",
+                "metadata",
             ]
             for row in rows:
                 data = FeatureStorage._row_to_dict(row, columns)
-                
+
                 # Filter by tags if specified
                 if tags:
                     feature_tags = set(data["tags"])

--- a/astroml/features/gnn/attention.py
+++ b/astroml/features/gnn/attention.py
@@ -132,7 +132,6 @@ class GATConv(nn.Module):
         N = x.size(0)
         assert edge_index.dim() == 2 and edge_index.size(0) == 2, "edge_index must be [2, E]"
         src, dst = edge_index[0], edge_index[1]
-        E = edge_index.size(1)
 
         Wh = self.lin(x)  # [N, H*F]
         Wh = Wh.view(N, self.heads, self.out_dim)  # [N, H, F]

--- a/astroml/features/graph/dask_builder.py
+++ b/astroml/features/graph/dask_builder.py
@@ -69,7 +69,7 @@ class DaskGraphBuilder:
         logger.info(f"Started Dask cluster: {self.client.dashboard_link}")
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(self, exc_type, _exc_val, _exc_tb):
         """Stop Dask cluster."""
         if self.client:
             self.client.close()

--- a/astroml/features/structural_importance.py
+++ b/astroml/features/structural_importance.py
@@ -478,7 +478,6 @@ def compute_eigenvector_centrality(
     """
     try:
         import scipy.sparse as sp
-        import scipy.sparse.linalg as spla
     except ImportError:
         warnings.warn(
             "SciPy is required for eigenvector centrality. Install with: pip install scipy"

--- a/astroml/ingestion/enhanced_stream.py
+++ b/astroml/ingestion/enhanced_stream.py
@@ -206,7 +206,7 @@ class EnhancedStellarStream:
         )
         return self
 
-    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+    async def __aexit__(self, exc_type, _exc_val, _exc_tb) -> None:
         """Async context manager exit."""
         self._running = False
         STREAM_CONNECTION_HEALTH.labels(

--- a/astroml/ingestion/stellar_ledger.py
+++ b/astroml/ingestion/stellar_ledger.py
@@ -30,7 +30,7 @@ class StellarLedgerDownloader:
         self._session = aiohttp.ClientSession()
         return self
 
-    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+    async def __aexit__(self, exc_type, _exc_val, _exc_tb) -> None:
         if self._session:
             await self._session.close()
 

--- a/astroml/ingestion/stream.py
+++ b/astroml/ingestion/stream.py
@@ -63,7 +63,7 @@ class HorizonStreamClient:
         )
         return self
 
-    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+    async def __aexit__(self, exc_type, _exc_val, _exc_tb) -> None:
         self._running = False
         if self._session:
             await self._session.close()

--- a/astroml/llm/anomaly_explanation.py
+++ b/astroml/llm/anomaly_explanation.py
@@ -38,12 +38,10 @@ class AnomalyExplanationEngine:
     def generate_explanation(
         self, anomaly_id: str, account_id: str, anomaly_data: dict[str, Any]
     ) -> dict[str, Any]:
-        features_str = self.extract_features(anomaly_data)
-        baseline_str = self.extract_baseline(account_id)
-
-        prompt = self.prompt_template.format(features=features_str, baseline=baseline_str)
-
         # Simulate LLM call
+        # features = self.extract_features(anomaly_data)
+        # baseline = self.extract_baseline(account_id)
+        # prompt = self.prompt_template.format(features=features, baseline=baseline)
         # response = self.llm.generate(prompt)
         # Mocking the response for batch processing performance
         response = {

--- a/astroml/llm/cache/invalidator.py
+++ b/astroml/llm/cache/invalidator.py
@@ -50,8 +50,6 @@ class CacheInvalidator:
             Number of entries invalidated
         """
         count = 0
-        cutoff_time = time.time() - max_age_seconds
-
         for tier_name, store in self.cache_manager.stores.items():
             if hasattr(store, "cleanup_expired"):
                 # SQLite has built-in cleanup

--- a/astroml/llm/code_review/checks/complexity.py
+++ b/astroml/llm/code_review/checks/complexity.py
@@ -127,7 +127,6 @@ class ComplexityCheck(BaseCheck):
 
     def _check_nesting_depth(self, tree: ast.AST, file_path: str) -> list[Suggestion]:
         """Check nesting depth of code blocks."""
-        suggestions = []
 
         class NestingDepthVisitor(ast.NodeVisitor):
             def __init__(self, max_depth: int):

--- a/astroml/llm/experimentation/analyzer.py
+++ b/astroml/llm/experimentation/analyzer.py
@@ -62,7 +62,6 @@ class StatisticalAnalyzer:
         z_alpha = 1.96  # For 5% alpha
         z_beta = 0.84  # For 80% power
 
-        effect_size = mde / baseline_rate
         p1 = baseline_rate
         p2 = baseline_rate + mde
 

--- a/astroml/llm/features/compute.py
+++ b/astroml/llm/features/compute.py
@@ -7,7 +7,6 @@ to generate embeddings, scores, confidence, and uncertainty estimates.
 from __future__ import annotations
 
 import logging
-import time
 
 import numpy as np
 import pandas as pd
@@ -48,7 +47,6 @@ def compute_fraud_scores(
     for _, row in data.iterrows():
         prompt = _build_fraud_prompt(row, prompt_version)
         try:
-            start = time.time()
             response = provider.generate_detailed(prompt, model=model)
             score = _parse_score(response.text)
             scores.append(score)
@@ -72,7 +70,6 @@ def compute_confidence_scores(
     for _, row in data.iterrows():
         prompt = _build_confidence_prompt(row, prompt_version)
         try:
-            start = time.time()
             response = provider.generate_detailed(prompt, model=model)
             score = _parse_score(response.text)
             confidence.append(score)

--- a/astroml/llm/features/integration.py
+++ b/astroml/llm/features/integration.py
@@ -8,15 +8,12 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from datetime import datetime
 from typing import Any
 
 import pandas as pd
 
 from astroml.cache import cached_feature
 from astroml.features.feature_store import (
-    FeatureDefinition,
-    FeatureStatus,
     FeatureStore,
     FeatureType,
 )
@@ -119,15 +116,6 @@ class LLMFeatureIntegration:
         ]
 
         for name, desc, ftype, extra_meta in embedding_features + score_features + meta_features:
-            feature_def = FeatureDefinition(
-                name=name,
-                description=desc,
-                feature_type=ftype,
-                tags=["llm", "auto-generated"],
-                owner="llm-features",
-                status=FeatureStatus.PRODUCTION,
-                metadata=extra_meta,
-            )
             self.store.register_feature(
                 name=name,
                 computer=None,
@@ -197,7 +185,6 @@ class LLMFeatureIntegration:
 
     def refresh_materialized_views(self) -> None:
         """Refresh all materialized views based on TTL policy."""
-        now = datetime.utcnow()
         for name in list(self._materialized_views.keys()):
             self._materialized_views.pop(name, None)
         logger.info("Refreshed all materialized views")

--- a/astroml/llm/fine_tuning/trainer.py
+++ b/astroml/llm/fine_tuning/trainer.py
@@ -173,7 +173,6 @@ class FineTuneTrainer:
     ) -> str:
         """Fine-tune using LoRA/QLoRA for open-source models."""
         try:
-            import torch
             from datasets import Dataset
             from peft import (
                 LoraConfig,

--- a/astroml/llm/labeling/labeler.py
+++ b/astroml/llm/labeling/labeler.py
@@ -1,13 +1,13 @@
 """Core labeling logic for LLM-based data labeling (issue #475)."""
+
 from __future__ import annotations
 
 import logging
 import uuid
-from dataclasses import dataclass, field
-from datetime import datetime
+from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
-from .schemas import Label, LabelSchema, LabelDefinition
+from .schemas import Label, LabelDefinition, LabelSchema
 
 logger = logging.getLogger(__name__)
 
@@ -113,8 +113,7 @@ class DataLabeler:
             # Update stats
             self.labeling_stats[schema_name]["total_labeled"] += 1
             auto_accepted = sum(
-                1 for l in labels
-                if l.confidence >= definition.confidence_threshold
+                1 for l in labels if l.confidence >= definition.confidence_threshold
             )
             self.labeling_stats[schema_name]["auto_accepted"] += auto_accepted
             self.labeling_stats[schema_name]["human_reviewed"] += len(labels) - auto_accepted

--- a/astroml/llm/labeling/schemas.py
+++ b/astroml/llm/labeling/schemas.py
@@ -1,11 +1,12 @@
 """Label schema definitions for LLM-based data labeling (issue #475)."""
+
 from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
-from typing import Any, Dict, List, Optional, Set
+from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 

--- a/astroml/llm/labeling/validators.py
+++ b/astroml/llm/labeling/validators.py
@@ -1,8 +1,8 @@
 """Label validation for LLM-based data labeling (issue #475)."""
+
 from __future__ import annotations
 
 import logging
-from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Optional
 
@@ -152,7 +152,9 @@ class LabelValidator:
 
         # Check label name matches
         if label.label_name != definition.name:
-            errors.append(f"Label name '{label.label_name}' does not match definition '{definition.name}'")
+            errors.append(
+                f"Label name '{label.label_name}' does not match definition '{definition.name}'"
+            )
 
         # Check allowed values
         if definition.allowed_values and label.value not in definition.allowed_values:

--- a/astroml/llm/monitoring/alerts.py
+++ b/astroml/llm/monitoring/alerts.py
@@ -1,4 +1,3 @@
-import time
 from typing import Any
 
 from .collector import get_metrics_collector
@@ -17,7 +16,6 @@ class AlertManager:
     def check_alerts(self) -> list[dict[str, Any]]:
         collector = get_metrics_collector()
         summary = collector.get_summary_metrics()
-        now = time.time()
 
         # Latency check
         if summary["p95_latency"] > self.thresholds["latency_p95_limit"]:

--- a/astroml/llm/monitoring/exporters.py
+++ b/astroml/llm/monitoring/exporters.py
@@ -65,7 +65,6 @@ class PrometheusExporter:
 
     def update_metrics(self):
         collector = get_metrics_collector()
-        summary = collector.get_summary_metrics()
 
         # In a real environment, we'd update gauges or increment counters as events happen.
         # For simplicity, we expose these metrics.

--- a/astroml/llm/observability/logger.py
+++ b/astroml/llm/observability/logger.py
@@ -14,14 +14,6 @@ import sys
 import time
 from typing import Any
 
-# Try structlog for production-grade structured logging
-try:
-    import structlog
-
-    _STRUCTLOG_AVAILABLE = True
-except ImportError:  # pragma: no cover
-    _STRUCTLOG_AVAILABLE = False
-
 logger = logging.getLogger(__name__)
 
 # Fields that must be redacted before logging

--- a/astroml/llm/observability/metrics.py
+++ b/astroml/llm/observability/metrics.py
@@ -13,7 +13,7 @@ from typing import Any
 
 # Optional prometheus_client — gracefully degrade if not installed
 try:
-    from prometheus_client import CollectorRegistry, Counter, Gauge, Histogram
+    from prometheus_client import CollectorRegistry, Counter, Histogram
 
     _PROMETHEUS_AVAILABLE = True
 except ImportError:  # pragma: no cover

--- a/astroml/llm/providers/embedding_router.py
+++ b/astroml/llm/providers/embedding_router.py
@@ -110,7 +110,7 @@ class EmbeddingRouter(EmbeddingProvider):
         return self._active
 
     def _try_embed(
-        self, provider: EmbeddingProvider, text: str, remaining_s: float
+        self, provider: EmbeddingProvider, text: str, _remaining_s: float
     ) -> tuple[list[float] | None, float]:
         """Attempt a single embed call; return (result, elapsed_s) or (None, elapsed_s)."""
         t0 = time.monotonic()
@@ -157,7 +157,6 @@ class EmbeddingRouter(EmbeddingProvider):
             If all providers fail or the fallback budget is exhausted.
         """
         deadline = time.monotonic() + _FALLBACK_BUDGET_S
-        last_error: Exception | None = None
 
         for provider in self.providers:
             remaining = deadline - time.monotonic()
@@ -185,7 +184,6 @@ class EmbeddingRouter(EmbeddingProvider):
     def embed_batch(self, texts: list[str]) -> list[list[float]]:
         """Embed a batch of texts using the first available provider, with fallback."""
         deadline = time.monotonic() + _FALLBACK_BUDGET_S
-        last_error: Exception | None = None
 
         for provider in self.providers:
             remaining = deadline - time.monotonic()
@@ -212,8 +210,6 @@ class EmbeddingRouter(EmbeddingProvider):
                     elapsed * 1000,
                     exc,
                 )
-                last_error = exc
-
         raise EmbeddingError(
             f"All embedding providers failed within {_FALLBACK_BUDGET_S * 1000:.0f} ms budget"
         )

--- a/astroml/llm/recommendations/engine.py
+++ b/astroml/llm/recommendations/engine.py
@@ -1,18 +1,19 @@
 """Recommendation engine for LLM-based recommendations (issue #474)."""
+
 from __future__ import annotations
 
 import logging
 from typing import Any, Dict, List, Optional
 
-from .profiler import UserProfiler, UserProfile, UserRole, ActivityType
-from .ranker import Recommendation, RecommendationRanker
 from .generators import (
-    RecommendationGenerator,
     FeatureRecommendationGenerator,
+    InsightGenerator,
     ModelRecommendationGenerator,
     QuerySuggestionGenerator,
-    InsightGenerator,
+    RecommendationGenerator,
 )
+from .profiler import ActivityType, UserProfiler, UserRole
+from .ranker import RecommendationRanker
 
 logger = logging.getLogger(__name__)
 
@@ -82,7 +83,8 @@ class RecommendationEngine:
         # Apply feedback filter (downvote previously rejected)
         user_feedback = self.feedback.get(user_id, {})
         filtered = [
-            rec for rec in ranked
+            rec
+            for rec in ranked
             if user_feedback.get(rec.id, True)  # Default to True if no feedback
         ]
 
@@ -149,15 +151,15 @@ class RecommendationEngine:
         else:
             # Global stats
             total_feedback = sum(len(fb) for fb in self.feedback.values())
-            total_accepted = sum(
-                sum(1 for v in fb.values() if v) for fb in self.feedback.values()
-            )
+            total_accepted = sum(sum(1 for v in fb.values() if v) for fb in self.feedback.values())
             return {
                 "total_users": len(self.feedback),
                 "total_feedback": total_feedback,
                 "total_accepted": total_accepted,
                 "total_rejected": total_feedback - total_accepted,
-                "global_acceptance_rate": total_accepted / total_feedback if total_feedback > 0 else 0,
+                "global_acceptance_rate": (
+                    total_accepted / total_feedback if total_feedback > 0 else 0
+                ),
             }
 
     def cleanup_old_data(self, days: int = 30) -> None:

--- a/astroml/llm/recommendations/generators.py
+++ b/astroml/llm/recommendations/generators.py
@@ -1,10 +1,11 @@
 """Recommendation generators for LLM-based recommendations (issue #474)."""
+
 from __future__ import annotations
 
 import logging
 import uuid
 from abc import ABC, abstractmethod
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 from .ranker import Recommendation
 
@@ -45,57 +46,63 @@ class FeatureRecommendationGenerator(RecommendationGenerator):
 
         # Fraud explanation feature
         if "fraud_detection" in interests or any("fraud" in p for p in recent_pages):
-            recommendations.append(Recommendation(
-                id=str(uuid.uuid4()),
-                type="feature",
-                title="Try the fraud explanation feature",
-                description="Get detailed explanations for fraud alerts using LLM-powered analysis",
-                explanation="Based on your interest in fraud detection, this feature can help you understand alert patterns",
-                action_url="/features/fraud-explanation",
-                confidence=0.8,
-                priority="high",
-                metadata={
-                    "interests": ["fraud_detection"],
-                    "skill_level": "intermediate",
-                    "related_pages": ["/alerts", "/fraud"],
-                },
-            ))
+            recommendations.append(
+                Recommendation(
+                    id=str(uuid.uuid4()),
+                    type="feature",
+                    title="Try the fraud explanation feature",
+                    description="Get detailed explanations for fraud alerts using LLM-powered analysis",
+                    explanation="Based on your interest in fraud detection, this feature can help you understand alert patterns",
+                    action_url="/features/fraud-explanation",
+                    confidence=0.8,
+                    priority="high",
+                    metadata={
+                        "interests": ["fraud_detection"],
+                        "skill_level": "intermediate",
+                        "related_pages": ["/alerts", "/fraud"],
+                    },
+                )
+            )
 
         # Batch scoring feature
         if "machine_learning" in interests or any("model" in p for p in recent_pages):
-            recommendations.append(Recommendation(
-                id=str(uuid.uuid4()),
-                type="feature",
-                title="Set up batch scoring for these accounts",
-                description="Configure automated batch scoring for multiple accounts at once",
-                explanation="You've been working with models - batch scoring can improve your workflow efficiency",
-                action_url="/models/batch-scoring",
-                confidence=0.7,
-                priority="medium",
-                metadata={
-                    "interests": ["machine_learning"],
-                    "skill_level": "advanced",
-                    "related_pages": ["/models", "/scoring"],
-                },
-            ))
+            recommendations.append(
+                Recommendation(
+                    id=str(uuid.uuid4()),
+                    type="feature",
+                    title="Set up batch scoring for these accounts",
+                    description="Configure automated batch scoring for multiple accounts at once",
+                    explanation="You've been working with models - batch scoring can improve your workflow efficiency",
+                    action_url="/models/batch-scoring",
+                    confidence=0.7,
+                    priority="medium",
+                    metadata={
+                        "interests": ["machine_learning"],
+                        "skill_level": "advanced",
+                        "related_pages": ["/models", "/scoring"],
+                    },
+                )
+            )
 
         # Feature engineering suggestions
         if "feature_engineering" in interests:
-            recommendations.append(Recommendation(
-                id=str(uuid.uuid4()),
-                type="feature",
-                title="Explore graph-based features",
-                description="Use transaction graph features to improve model performance",
-                explanation="Graph-based features can capture structural patterns in transaction networks",
-                action_url="/features/graph",
-                confidence=0.6,
-                priority="medium",
-                metadata={
-                    "interests": ["feature_engineering", "graph_analysis"],
-                    "skill_level": "intermediate",
-                    "related_pages": ["/features"],
-                },
-            ))
+            recommendations.append(
+                Recommendation(
+                    id=str(uuid.uuid4()),
+                    type="feature",
+                    title="Explore graph-based features",
+                    description="Use transaction graph features to improve model performance",
+                    explanation="Graph-based features can capture structural patterns in transaction networks",
+                    action_url="/features/graph",
+                    confidence=0.6,
+                    priority="medium",
+                    metadata={
+                        "interests": ["feature_engineering", "graph_analysis"],
+                        "skill_level": "intermediate",
+                        "related_pages": ["/features"],
+                    },
+                )
+            )
 
         return recommendations
 
@@ -117,38 +124,42 @@ class ModelRecommendationGenerator(RecommendationGenerator):
 
         # Model version recommendation
         if skill_level in ["intermediate", "advanced"]:
-            recommendations.append(Recommendation(
+            recommendations.append(
+                Recommendation(
+                    id=str(uuid.uuid4()),
+                    type="model",
+                    title="Model v2.1 shows 15% improvement",
+                    description="The latest model version shows improved performance on recent data",
+                    explanation="Based on evaluation metrics, upgrading to v2.1 could improve your fraud detection accuracy",
+                    action_url="/models/versions",
+                    confidence=0.75,
+                    priority="high",
+                    metadata={
+                        "interests": ["machine_learning"],
+                        "skill_level": "advanced",
+                        "related_pages": ["/models"],
+                    },
+                )
+            )
+
+        # Retrain recommendation
+        recommendations.append(
+            Recommendation(
                 id=str(uuid.uuid4()),
                 type="model",
-                title="Model v2.1 shows 15% improvement",
-                description="The latest model version shows improved performance on recent data",
-                explanation="Based on evaluation metrics, upgrading to v2.1 could improve your fraud detection accuracy",
-                action_url="/models/versions",
-                confidence=0.75,
-                priority="high",
+                title="Retrain model with recent data",
+                description="Your model training data is 30 days old - consider retraining with recent transactions",
+                explanation="Models can drift over time - retraining with fresh data maintains performance",
+                action_url="/models/retrain",
+                confidence=0.65,
+                priority="medium",
                 metadata={
                     "interests": ["machine_learning"],
                     "skill_level": "advanced",
                     "related_pages": ["/models"],
                 },
-            ))
-
-        # Retrain recommendation
-        recommendations.append(Recommendation(
-            id=str(uuid.uuid4()),
-            type="model",
-            title="Retrain model with recent data",
-            description="Your model training data is 30 days old - consider retraining with recent transactions",
-            explanation="Models can drift over time - retraining with fresh data maintains performance",
-            action_url="/models/retrain",
-            confidence=0.65,
-            priority="medium",
-            metadata={
-                "interests": ["machine_learning"],
-                "skill_level": "advanced",
-                "related_pages": ["/models"],
-            },
-        ))
+            )
+        )
 
         return recommendations
 
@@ -170,38 +181,42 @@ class QuerySuggestionGenerator(RecommendationGenerator):
 
         # Similar queries
         if any("query" in p for p in recent_pages):
-            recommendations.append(Recommendation(
-                id=str(uuid.uuid4()),
-                type="query",
-                title="Similar queries: high-value transactions",
-                description="Try querying for transactions above $10,000 for fraud analysis",
-                explanation="Users with similar interests often query high-value transactions",
-                action_url="/query?template=high-value",
-                confidence=0.6,
-                priority="low",
-                metadata={
-                    "interests": ["fraud_detection"],
-                    "skill_level": "beginner",
-                    "related_pages": ["/query"],
-                },
-            ))
+            recommendations.append(
+                Recommendation(
+                    id=str(uuid.uuid4()),
+                    type="query",
+                    title="Similar queries: high-value transactions",
+                    description="Try querying for transactions above $10,000 for fraud analysis",
+                    explanation="Users with similar interests often query high-value transactions",
+                    action_url="/query?template=high-value",
+                    confidence=0.6,
+                    priority="low",
+                    metadata={
+                        "interests": ["fraud_detection"],
+                        "skill_level": "beginner",
+                        "related_pages": ["/query"],
+                    },
+                )
+            )
 
         # Related metrics
-        recommendations.append(Recommendation(
-            id=str(uuid.uuid4()),
-            type="query",
-            title="Related metrics: transaction frequency",
-            description="Explore transaction frequency metrics for anomaly detection",
-            explanation="Frequency analysis can reveal unusual patterns in transaction behavior",
-            action_url="/metrics/frequency",
-            confidence=0.55,
-            priority="low",
-            metadata={
-                "interests": ["fraud_detection", "feature_engineering"],
-                "skill_level": "intermediate",
-                "related_pages": ["/metrics"],
-            },
-        ))
+        recommendations.append(
+            Recommendation(
+                id=str(uuid.uuid4()),
+                type="query",
+                title="Related metrics: transaction frequency",
+                description="Explore transaction frequency metrics for anomaly detection",
+                explanation="Frequency analysis can reveal unusual patterns in transaction behavior",
+                action_url="/metrics/frequency",
+                confidence=0.55,
+                priority="low",
+                metadata={
+                    "interests": ["fraud_detection", "feature_engineering"],
+                    "skill_level": "intermediate",
+                    "related_pages": ["/metrics"],
+                },
+            )
+        )
 
         return recommendations
 
@@ -223,37 +238,41 @@ class InsightGenerator(RecommendationGenerator):
 
         # Pattern detection insight
         if "fraud_detection" in interests:
-            recommendations.append(Recommendation(
-                id=str(uuid.uuid4()),
-                type="insight",
-                title="Unusual pattern detected in transactions",
-                description="We've detected a spike in circular transactions in the last 24 hours",
-                explanation="Anomaly detection identified a 3x increase in circular transaction patterns",
-                action_url="/insights/circular-transactions",
-                confidence=0.85,
-                priority="high",
-                metadata={
-                    "interests": ["fraud_detection"],
-                    "skill_level": "intermediate",
-                    "related_pages": ["/insights", "/alerts"],
-                },
-            ))
+            recommendations.append(
+                Recommendation(
+                    id=str(uuid.uuid4()),
+                    type="insight",
+                    title="Unusual pattern detected in transactions",
+                    description="We've detected a spike in circular transactions in the last 24 hours",
+                    explanation="Anomaly detection identified a 3x increase in circular transaction patterns",
+                    action_url="/insights/circular-transactions",
+                    confidence=0.85,
+                    priority="high",
+                    metadata={
+                        "interests": ["fraud_detection"],
+                        "skill_level": "intermediate",
+                        "related_pages": ["/insights", "/alerts"],
+                    },
+                )
+            )
 
         # Threshold adjustment insight
-        recommendations.append(Recommendation(
-            id=str(uuid.uuid4()),
-            type="insight",
-            title="Consider adjusting fraud threshold",
-            description="Current false positive rate is 12% - adjusting threshold could improve precision",
-            explanation="Based on recent alert performance, a threshold adjustment may reduce false positives",
-            action_url="/models/thresholds",
-            confidence=0.7,
-            priority="medium",
-            metadata={
-                "interests": ["machine_learning", "fraud_detection"],
-                "skill_level": "advanced",
-                "related_pages": ["/models", "/alerts"],
-            },
-        ))
+        recommendations.append(
+            Recommendation(
+                id=str(uuid.uuid4()),
+                type="insight",
+                title="Consider adjusting fraud threshold",
+                description="Current false positive rate is 12% - adjusting threshold could improve precision",
+                explanation="Based on recent alert performance, a threshold adjustment may reduce false positives",
+                action_url="/models/thresholds",
+                confidence=0.7,
+                priority="medium",
+                metadata={
+                    "interests": ["machine_learning", "fraud_detection"],
+                    "skill_level": "advanced",
+                    "related_pages": ["/models", "/alerts"],
+                },
+            )
+        )
 
         return recommendations

--- a/astroml/llm/structured/correction.py
+++ b/astroml/llm/structured/correction.py
@@ -50,7 +50,6 @@ class AutoCorrector:
                 continue
 
             value = corrected[name]
-            constraints = field.metadata
 
             # Check for ge/le constraints
             if hasattr(field, "ge") and field.ge is not None:

--- a/astroml/llm/testing/reviewer.py
+++ b/astroml/llm/testing/reviewer.py
@@ -130,7 +130,6 @@ class TestReviewer:
         """Generate a human-readable summary report."""
         avg_score = sum(r.score for r in results) / max(len(results), 1)
         all_issues = [i for r in results for i in r.issues]
-        all_suggestions = [s for r in results for s in r.suggestions]
         all_tags = set(t for r in results for t in r.coverage_tags)
 
         report = [

--- a/astroml/models/temporal.py
+++ b/astroml/models/temporal.py
@@ -5,41 +5,42 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from torch_geometric.nn import GATConv, GCNConv, MessagePassing, SAGEConv
-from torch_geometric.utils import add_self_loops, degree
+from torch_geometric.utils import degree
 
 
 class TemporalEncoding(nn.Module):
     """Temporal encoding using sinusoidal functions."""
-    
+
     def __init__(self, temporal_dim: int, max_time: float = 1000.0):
         super().__init__()
         self.temporal_dim = temporal_dim
         self.max_time = max_time
-        
+
         # Create sinusoidal encoding
         position = torch.arange(0, temporal_dim, dtype=torch.float).unsqueeze(1)
-        div_term = torch.exp(torch.arange(0, temporal_dim, 2).float() * 
-                           (-math.log(10000.0) / temporal_dim))
-        
-        self.register_buffer('encoding', torch.zeros(temporal_dim))
+        div_term = torch.exp(
+            torch.arange(0, temporal_dim, 2).float() * (-math.log(10000.0) / temporal_dim)
+        )
+
+        self.register_buffer("encoding", torch.zeros(temporal_dim))
         self.encoding[0::2] = torch.sin(position / div_term)
         self.encoding[1::2] = torch.cos(position / div_term)
-    
+
     def forward(self, timestamps: torch.Tensor) -> torch.Tensor:
         """Encode timestamps to temporal features.
-        
+
         Args:
             timestamps: Tensor of shape [num_nodes] with timestamp values
-            
+
         Returns:
             Temporal encoding tensor of shape [num_nodes, temporal_dim]
         """
         # Normalize timestamps to [0, 1]
         normalized_time = timestamps / self.max_time
-        
+
         # Scale to encoding dimension
         scaled_time = normalized_time * self.temporal_dim
-        
+
         # Use sinusoidal encoding
         indices = scaled_time.long() % self.temporal_dim
         return self.encoding[indices]
@@ -47,65 +48,65 @@ class TemporalEncoding(nn.Module):
 
 class TemporalAttention(nn.Module):
     """Temporal attention mechanism for time-aware node representations."""
-    
+
     def __init__(self, input_dim: int, temporal_dim: int, heads: int = 8):
         super().__init__()
         self.input_dim = input_dim
         self.temporal_dim = temporal_dim
         self.heads = heads
         self.head_dim = input_dim // heads
-        
+
         assert input_dim % heads == 0, "input_dim must be divisible by heads"
-        
+
         # Query, Key, Value projections
         self.query = nn.Linear(input_dim + temporal_dim, input_dim)
         self.key = nn.Linear(input_dim + temporal_dim, input_dim)
         self.value = nn.Linear(input_dim + temporal_dim, input_dim)
-        
+
         # Output projection
         self.out_proj = nn.Linear(input_dim, input_dim)
-        
+
         # Dropout
         self.dropout = nn.Dropout(0.1)
-    
+
     def forward(self, x: torch.Tensor, temporal_encoding: torch.Tensor) -> torch.Tensor:
         """Apply temporal attention.
-        
+
         Args:
             x: Node features [num_nodes, input_dim]
             temporal_encoding: Temporal features [num_nodes, temporal_dim]
-            
+
         Returns:
             Attention-enhanced features [num_nodes, input_dim]
         """
         batch_size = x.size(0)
-        
+
         # Combine features with temporal encoding
         combined = torch.cat([x, temporal_encoding], dim=-1)
-        
+
         # Compute Q, K, V
         Q = self.query(combined).view(batch_size, self.heads, self.head_dim)
         K = self.key(combined).view(batch_size, self.heads, self.head_dim)
         V = self.value(combined).view(batch_size, self.heads, self.head_dim)
-        
+
         # Compute attention scores
         scores = torch.matmul(Q, K.transpose(-2, -1)) / math.sqrt(self.head_dim)
         attn_weights = F.softmax(scores, dim=-1)
         attn_weights = self.dropout(attn_weights)
-        
+
         # Apply attention
         attended = torch.matmul(attn_weights, V)
         attended = attended.view(batch_size, self.input_dim)
-        
+
         # Output projection
         output = self.out_proj(attended)
-        
+
         return output + x  # Residual connection
 
 
 class TemporalGCN(nn.Module):
     """Temporal Graph Convolutional Network with time encoding."""
-    
+
     def __init__(
         self,
         input_dim: int,
@@ -114,10 +115,10 @@ class TemporalGCN(nn.Module):
         temporal_dim: int = 32,
         dropout: float = 0.5,
         time_encoding: str = "sinusoidal",
-        use_attention: bool = True
+        use_attention: bool = True,
     ):
         super().__init__()
-        
+
         self.input_dim = input_dim
         self.hidden_dims = hidden_dims
         self.output_dim = output_dim
@@ -125,7 +126,7 @@ class TemporalGCN(nn.Module):
         self.dropout = dropout
         self.time_encoding = time_encoding
         self.use_attention = use_attention
-        
+
         # Temporal encoding
         if time_encoding == "sinusoidal":
             self.temporal_encoder = TemporalEncoding(temporal_dim)
@@ -133,84 +134,82 @@ class TemporalGCN(nn.Module):
             self.temporal_encoder = nn.Linear(1, temporal_dim)
         else:
             raise ValueError(f"Unknown time encoding: {time_encoding}")
-        
+
         # Adjust input dimension for temporal features
         effective_input_dim = input_dim + temporal_dim
-        
+
         # Graph convolution layers
         self.convs = nn.ModuleList()
-        
+
         # Input layer
         self.convs.append(GCNConv(effective_input_dim, hidden_dims[0]))
-        
+
         # Hidden layers
         for i in range(len(hidden_dims) - 1):
             self.convs.append(GCNConv(hidden_dims[i], hidden_dims[i + 1]))
-        
+
         # Output layer
         self.convs.append(GCNConv(hidden_dims[-1], output_dim))
-        
+
         # Temporal attention
         if use_attention:
-            self.temporal_attention = TemporalAttention(
-                hidden_dims[-1], temporal_dim, heads=8
-            )
-        
+            self.temporal_attention = TemporalAttention(hidden_dims[-1], temporal_dim, heads=8)
+
         # Dropout
         self.dropout_layer = nn.Dropout(dropout)
-    
+
     def forward(
         self,
         x: torch.Tensor,
         edge_index: torch.Tensor,
         edge_time: Optional[torch.Tensor] = None,
         node_time: Optional[torch.Tensor] = None,
-        edge_attr: Optional[torch.Tensor] = None
+        edge_attr: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         """Forward pass with temporal information.
-        
+
         Args:
             x: Node features [num_nodes, input_dim]
             edge_index: Edge indices [2, num_edges]
             edge_time: Edge timestamps [num_edges] (optional)
             node_time: Node timestamps [num_nodes] (optional)
             edge_attr: Edge attributes [num_edges, edge_attr_dim] (optional)
-            
+
         Returns:
             Node predictions [num_nodes, output_dim]
         """
         # Default timestamps if not provided
         if node_time is None:
             node_time = torch.zeros(x.size(0), device=x.device)
-        
+
         # Encode temporal information
         if self.time_encoding == "learnable":
             temporal_encoding = self.temporal_encoder(node_time.unsqueeze(-1))
         else:
             temporal_encoding = self.temporal_encoder(node_time)
-        
+
         # Combine features with temporal encoding
         x_combined = torch.cat([x, temporal_encoding], dim=-1)
-        
+
         # Apply graph convolutions
         for i, conv in enumerate(self.convs[:-1]):
             x_combined = conv(x_combined, edge_index, edge_attr)
             x_combined = F.relu(x_combined)
             x_combined = self.dropout_layer(x_combined)
-        
+
         # Output layer
         x_out = self.convs[-1](x_combined, edge_index, edge_attr)
-        
+
         # Apply temporal attention if enabled
-        if self.use_attention and hasattr(self, 'temporal_attention'):
+        if self.use_attention and hasattr(self, "temporal_attention"):
             x_out = self.temporal_attention(x_out, temporal_encoding)
-        
+
         return F.log_softmax(x_out, dim=1)
 
 
 class TemporalGraphSAGE(nn.Module):
     """Temporal GraphSAGE with temporal encoding."""
-    
+
     def __init__(
         self,
         input_dim: int,
@@ -219,10 +218,10 @@ class TemporalGraphSAGE(nn.Module):
         temporal_dim: int = 32,
         dropout: float = 0.5,
         num_layers: int = 2,
-        aggregator: str = "mean"
+        aggregator: str = "mean",
     ):
         super().__init__()
-        
+
         self.input_dim = input_dim
         self.hidden_dims = hidden_dims
         self.output_dim = output_dim
@@ -230,70 +229,67 @@ class TemporalGraphSAGE(nn.Module):
         self.dropout = dropout
         self.num_layers = num_layers
         self.aggregator = aggregator
-        
+
         # Temporal encoding
         self.temporal_encoder = TemporalEncoding(temporal_dim)
-        
+
         # Adjust input dimension for temporal features
         effective_input_dim = input_dim + temporal_dim
-        
+
         # GraphSAGE layers
         self.convs = nn.ModuleList()
-        
+
         # Input layer
         self.convs.append(SAGEConv(effective_input_dim, hidden_dims[0], aggr=aggregator))
-        
+
         # Hidden layers
         for i in range(num_layers - 1):
             self.convs.append(SAGEConv(hidden_dims[i], hidden_dims[i + 1], aggr=aggregator))
-        
+
         # Output layer
         self.convs.append(SAGEConv(hidden_dims[-1], output_dim, aggr=aggregator))
-        
+
         # Dropout
         self.dropout_layer = nn.Dropout(dropout)
-    
+
     def forward(
-        self,
-        x: torch.Tensor,
-        edge_index: torch.Tensor,
-        node_time: Optional[torch.Tensor] = None
+        self, x: torch.Tensor, edge_index: torch.Tensor, node_time: Optional[torch.Tensor] = None
     ) -> torch.Tensor:
         """Forward pass with temporal information.
-        
+
         Args:
             x: Node features [num_nodes, input_dim]
             edge_index: Edge indices [2, num_edges]
             node_time: Node timestamps [num_nodes] (optional)
-            
+
         Returns:
             Node predictions [num_nodes, output_dim]
         """
         # Default timestamps if not provided
         if node_time is None:
             node_time = torch.zeros(x.size(0), device=x.device)
-        
+
         # Encode temporal information
         temporal_encoding = self.temporal_encoder(node_time)
-        
+
         # Combine features with temporal encoding
         x_combined = torch.cat([x, temporal_encoding], dim=-1)
-        
+
         # Apply GraphSAGE layers
         for i, conv in enumerate(self.convs[:-1]):
             x_combined = conv(x_combined, edge_index)
             x_combined = F.relu(x_combined)
             x_combined = self.dropout_layer(x_combined)
-        
+
         # Output layer
         x_out = self.convs[-1](x_combined, edge_index)
-        
+
         return F.log_softmax(x_out, dim=1)
 
 
 class TemporalGAT(nn.Module):
     """Temporal Graph Attention Network with temporal encoding."""
-    
+
     def __init__(
         self,
         input_dim: int,
@@ -302,10 +298,10 @@ class TemporalGAT(nn.Module):
         temporal_dim: int = 32,
         dropout: float = 0.5,
         heads: int = 8,
-        concat: bool = True
+        concat: bool = True,
     ):
         super().__init__()
-        
+
         self.input_dim = input_dim
         self.hidden_dims = hidden_dims
         self.output_dim = output_dim
@@ -313,146 +309,141 @@ class TemporalGAT(nn.Module):
         self.dropout = dropout
         self.heads = heads
         self.concat = concat
-        
+
         # Temporal encoding
         self.temporal_encoder = TemporalEncoding(temporal_dim)
-        
+
         # Adjust input dimension for temporal features
         effective_input_dim = input_dim + temporal_dim
-        
+
         # GAT layers
         self.convs = nn.ModuleList()
-        
+
         # Input layer
-        self.convs.append(GATConv(
-            effective_input_dim, 
-            hidden_dims[0] // heads, 
-            heads=heads, 
-            dropout=dropout, 
-            concat=concat
-        ))
-        
+        self.convs.append(
+            GATConv(
+                effective_input_dim,
+                hidden_dims[0] // heads,
+                heads=heads,
+                dropout=dropout,
+                concat=concat,
+            )
+        )
+
         # Hidden layers
         for i in range(len(hidden_dims) - 1):
-            self.convs.append(GATConv(
-                hidden_dims[i], 
-                hidden_dims[i + 1] // heads, 
-                heads=heads, 
-                dropout=dropout, 
-                concat=concat
-            ))
-        
+            self.convs.append(
+                GATConv(
+                    hidden_dims[i],
+                    hidden_dims[i + 1] // heads,
+                    heads=heads,
+                    dropout=dropout,
+                    concat=concat,
+                )
+            )
+
         # Output layer (no multi-head for final layer)
-        self.convs.append(GATConv(
-            hidden_dims[-1], 
-            output_dim, 
-            heads=1, 
-            dropout=dropout, 
-            concat=False
-        ))
-        
+        self.convs.append(
+            GATConv(hidden_dims[-1], output_dim, heads=1, dropout=dropout, concat=False)
+        )
+
         # Dropout
         self.dropout_layer = nn.Dropout(dropout)
-    
+
     def forward(
         self,
         x: torch.Tensor,
         edge_index: torch.Tensor,
         node_time: Optional[torch.Tensor] = None,
-        edge_attr: Optional[torch.Tensor] = None
+        edge_attr: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         """Forward pass with temporal information.
-        
+
         Args:
             x: Node features [num_nodes, input_dim]
             edge_index: Edge indices [2, num_edges]
             node_time: Node timestamps [num_nodes] (optional)
             edge_attr: Edge attributes [num_edges, edge_attr_dim] (optional)
-            
+
         Returns:
             Node predictions [num_nodes, output_dim]
         """
         # Default timestamps if not provided
         if node_time is None:
             node_time = torch.zeros(x.size(0), device=x.device)
-        
+
         # Encode temporal information
         temporal_encoding = self.temporal_encoder(node_time)
-        
+
         # Combine features with temporal encoding
         x_combined = torch.cat([x, temporal_encoding], dim=-1)
-        
+
         # Apply GAT layers
         for i, conv in enumerate(self.convs[:-1]):
             x_combined = conv(x_combined, edge_index, edge_attr)
             x_combined = F.elu(x_combined)  # GAT typically uses ELU
             x_combined = self.dropout_layer(x_combined)
-        
+
         # Output layer
         x_out = self.convs[-1](x_combined, edge_index, edge_attr)
-        
+
         return F.log_softmax(x_out, dim=1)
 
 
 class TemporalEdgeConv(MessagePassing):
     """Temporal edge convolution for dynamic edge features."""
-    
+
     def __init__(
-        self,
-        in_channels: int,
-        out_channels: int,
-        temporal_dim: int = 32,
-        aggr: str = "max"
+        self, in_channels: int, out_channels: int, temporal_dim: int = 32, aggr: str = "max"
     ):
         super().__init__(aggr=aggr)
-        
+
         self.in_channels = in_channels
         self.out_channels = out_channels
         self.temporal_dim = temporal_dim
-        
+
         # Message function
         self.message_mlp = nn.Sequential(
             nn.Linear(2 * in_channels + temporal_dim, out_channels),
             nn.ReLU(),
-            nn.Linear(out_channels, out_channels)
+            nn.Linear(out_channels, out_channels),
         )
-        
+
         # Update function
         self.update_mlp = nn.Sequential(
             nn.Linear(in_channels + out_channels, out_channels),
             nn.ReLU(),
-            nn.Linear(out_channels, out_channels)
+            nn.Linear(out_channels, out_channels),
         )
-    
+
     def forward(
-        self,
-        x: torch.Tensor,
-        edge_index: torch.Tensor,
-        edge_time: torch.Tensor
+        self, x: torch.Tensor, edge_index: torch.Tensor, edge_time: torch.Tensor
     ) -> torch.Tensor:
         """Forward pass for temporal edge convolution.
-        
+
         Args:
             x: Node features [num_nodes, in_channels]
             edge_index: Edge indices [2, num_edges]
             edge_time: Edge timestamps [num_edges]
-            
+
         Returns:
             Updated node features [num_nodes, out_channels]
         """
         # Temporal encoding for edges
         temporal_encoder = TemporalEncoding(self.temporal_dim)
         edge_temporal_encoding = temporal_encoder(edge_time)
-        
+
         # Propagate messages
         return self.propagate(edge_index, x=x, edge_temporal=edge_temporal_encoding)
-    
-    def message(self, x_j: torch.Tensor, x_i: torch.Tensor, edge_temporal: torch.Tensor) -> torch.Tensor:
+
+    def message(
+        self, x_j: torch.Tensor, x_i: torch.Tensor, edge_temporal: torch.Tensor
+    ) -> torch.Tensor:
         """Message function for edge convolution."""
         # Combine source, target, and temporal features
         combined = torch.cat([x_i, x_j, edge_temporal], dim=-1)
         return self.message_mlp(combined)
-    
+
     def update(self, aggr_out: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
         """Update function for edge convolution."""
         combined = torch.cat([x, aggr_out], dim=-1)
@@ -461,7 +452,7 @@ class TemporalEdgeConv(MessagePassing):
 
 class TemporalGraphTransformer(nn.Module):
     """Temporal Graph Transformer with attention mechanisms."""
-    
+
     def __init__(
         self,
         input_dim: int,
@@ -470,10 +461,10 @@ class TemporalGraphTransformer(nn.Module):
         temporal_dim: int = 32,
         num_heads: int = 8,
         num_layers: int = 3,
-        dropout: float = 0.1
+        dropout: float = 0.1,
     ):
         super().__init__()
-        
+
         self.input_dim = input_dim
         self.hidden_dim = hidden_dim
         self.output_dim = output_dim
@@ -481,93 +472,92 @@ class TemporalGraphTransformer(nn.Module):
         self.num_heads = num_heads
         self.num_layers = num_layers
         self.dropout = dropout
-        
+
         # Temporal encoding
         self.temporal_encoder = TemporalEncoding(temporal_dim)
-        
+
         # Input projection
         self.input_proj = nn.Linear(input_dim + temporal_dim, hidden_dim)
-        
+
         # Transformer layers
-        self.transformer_layers = nn.ModuleList([
-            nn.TransformerEncoderLayer(
-                d_model=hidden_dim,
-                nhead=num_heads,
-                dropout=dropout,
-                batch_first=True
-            ) for _ in range(num_layers)
-        ])
-        
+        self.transformer_layers = nn.ModuleList(
+            [
+                nn.TransformerEncoderLayer(
+                    d_model=hidden_dim, nhead=num_heads, dropout=dropout, batch_first=True
+                )
+                for _ in range(num_layers)
+            ]
+        )
+
         # Output projection
         self.output_proj = nn.Linear(hidden_dim, output_dim)
-        
+
         # Positional encoding
         self.pos_encoding = self._create_positional_encoding(1000, hidden_dim)
-    
+
     def _create_positional_encoding(self, max_len: int, d_model: int) -> torch.Tensor:
         """Create positional encoding."""
         pe = torch.zeros(max_len, d_model)
         position = torch.arange(0, max_len, dtype=torch.float).unsqueeze(1)
-        div_term = torch.exp(torch.arange(0, d_model, 2).float() * 
-                           (-math.log(10000.0) / d_model))
-        
+        div_term = torch.exp(torch.arange(0, d_model, 2).float() * (-math.log(10000.0) / d_model))
+
         pe[:, 0::2] = torch.sin(position * div_term)
         pe[:, 1::2] = torch.cos(position * div_term)
-        
+
         return pe.unsqueeze(0)
-    
+
     def forward(
         self,
         x: torch.Tensor,
         edge_index: torch.Tensor,
         node_time: Optional[torch.Tensor] = None,
-        edge_time: Optional[torch.Tensor] = None
+        edge_time: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         """Forward pass for temporal graph transformer.
-        
+
         Args:
             x: Node features [num_nodes, input_dim]
             edge_index: Edge indices [2, num_edges]
             node_time: Node timestamps [num_nodes] (optional)
             edge_time: Edge timestamps [num_edges] (optional)
-            
+
         Returns:
             Node predictions [num_nodes, output_dim]
         """
         # Default timestamps if not provided
         if node_time is None:
             node_time = torch.zeros(x.size(0), device=x.device)
-        
+
         # Encode temporal information
         temporal_encoding = self.temporal_encoder(node_time)
-        
+
         # Combine features with temporal encoding
         x_combined = torch.cat([x, temporal_encoding], dim=-1)
-        
+
         # Input projection
         x_proj = self.input_proj(x_combined)
-        
+
         # Add positional encoding
         seq_len = x_proj.size(0)
         pos_encoding = self.pos_encoding[:, :seq_len, :].to(x_proj.device)
         x_proj = x_proj + pos_encoding.squeeze(0)
-        
+
         # Apply transformer layers
         x_transformed = x_proj.unsqueeze(0)  # Add batch dimension
         for layer in self.transformer_layers:
             x_transformed = layer(x_transformed)
-        
+
         x_transformed = x_transformed.squeeze(0)  # Remove batch dimension
-        
+
         # Output projection
         x_out = self.output_proj(x_transformed)
-        
+
         return F.log_softmax(x_out, dim=1)
 
 
 class TemporalModelFactory:
     """Factory for creating temporal GNN models."""
-    
+
     @staticmethod
     def create_temporal_gcn(config) -> TemporalGCN:
         """Create TemporalGCN model."""
@@ -575,12 +565,12 @@ class TemporalModelFactory:
             input_dim=config.input_dim,
             hidden_dims=config.hidden_dims,
             output_dim=config.output_dim,
-            temporal_dim=config.get('temporal_dim', 32),
-            dropout=config.get('dropout', 0.5),
-            time_encoding=config.get('time_encoding', 'sinusoidal'),
-            use_attention=config.get('use_attention', True)
+            temporal_dim=config.get("temporal_dim", 32),
+            dropout=config.get("dropout", 0.5),
+            time_encoding=config.get("time_encoding", "sinusoidal"),
+            use_attention=config.get("use_attention", True),
         )
-    
+
     @staticmethod
     def create_temporal_sage(config) -> TemporalGraphSAGE:
         """Create TemporalGraphSAGE model."""
@@ -588,12 +578,12 @@ class TemporalModelFactory:
             input_dim=config.input_dim,
             hidden_dims=config.hidden_dims,
             output_dim=config.output_dim,
-            temporal_dim=config.get('temporal_dim', 32),
-            dropout=config.get('dropout', 0.5),
-            num_layers=config.get('num_layers', 2),
-            aggregator=config.get('aggregator', 'mean')
+            temporal_dim=config.get("temporal_dim", 32),
+            dropout=config.get("dropout", 0.5),
+            num_layers=config.get("num_layers", 2),
+            aggregator=config.get("aggregator", "mean"),
         )
-    
+
     @staticmethod
     def create_temporal_gat(config) -> TemporalGAT:
         """Create TemporalGAT model."""
@@ -601,12 +591,12 @@ class TemporalModelFactory:
             input_dim=config.input_dim,
             hidden_dims=config.hidden_dims,
             output_dim=config.output_dim,
-            temporal_dim=config.get('temporal_dim', 32),
-            dropout=config.get('dropout', 0.5),
-            heads=config.get('heads', 8),
-            concat=config.get('concat', True)
+            temporal_dim=config.get("temporal_dim", 32),
+            dropout=config.get("dropout", 0.5),
+            heads=config.get("heads", 8),
+            concat=config.get("concat", True),
         )
-    
+
     @staticmethod
     def create_temporal_transformer(config) -> TemporalGraphTransformer:
         """Create TemporalGraphTransformer model."""
@@ -614,8 +604,8 @@ class TemporalModelFactory:
             input_dim=config.input_dim,
             hidden_dim=config.hidden_dim,
             output_dim=config.output_dim,
-            temporal_dim=config.get('temporal_dim', 32),
-            num_heads=config.get('num_heads', 8),
-            num_layers=config.get('num_layers', 3),
-            dropout=config.get('dropout', 0.1)
+            temporal_dim=config.get("temporal_dim", 32),
+            num_heads=config.get("num_heads", 8),
+            num_layers=config.get("num_layers", 3),
+            dropout=config.get("dropout", 0.1),
         )

--- a/astroml/tasks/labeling.py
+++ b/astroml/tasks/labeling.py
@@ -1,21 +1,20 @@
 """Batch labeling worker for LLM-based data labeling (issue #475)."""
+
 from __future__ import annotations
 
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 from astroml.llm.labeling import (
-    DataLabeler,
     ConsensusLabeler,
+    DataLabeler,
     HumanReviewQueue,
-    LabelSchema,
     LabelDefinition,
-    LabelType,
 )
 from astroml.llm.labeling.schemas import (
-    FRAUD_CLASSIFICATION_SCHEMA,
     ALERT_CATEGORIZATION_SCHEMA,
     ENTITY_RESOLUTION_SCHEMA,
+    FRAUD_CLASSIFICATION_SCHEMA,
     SENTIMENT_SCHEMA,
 )
 
@@ -79,7 +78,9 @@ class BatchLabelingWorker:
                 # Check for low confidence labels
                 for label in result.labels:
                     if label.confidence < auto_review_threshold:
-                        definition = self.labeler.schemas[schema_name].get_definition(label.label_name)
+                        definition = self.labeler.schemas[schema_name].get_definition(
+                            label.label_name
+                        )
                         if definition and definition.requires_human_review:
                             self._add_to_review_queue(item_id, data, result, definition)
                             low_confidence_items.append(item_id)
@@ -109,10 +110,14 @@ class BatchLabelingWorker:
             labeling_result: Labeling result
             definition: Label definition
         """
-        if hasattr(labeling_result, 'labels'):
+        if hasattr(labeling_result, "labels"):
             labels = labeling_result.labels
         else:
-            labels = labeling_result.individual_results[0]['result']['labels'] if labeling_result.individual_results else []
+            labels = (
+                labeling_result.individual_results[0]["result"]["labels"]
+                if labeling_result.individual_results
+                else []
+            )
 
         self.review_queue.add_task(
             item_id=item_id,

--- a/astroml/utils/logging.py
+++ b/astroml/utils/logging.py
@@ -148,7 +148,7 @@ class CorrelationId:
         self.token = _correlation_id.set(self.correlation_id)
         return self.correlation_id
 
-    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+    def __exit__(self, exc_type, _exc_val, _exc_tb) -> None:
         if self.token is not None:
             _correlation_id.reset(self.token)
 

--- a/astroml/utils/temporal.py
+++ b/astroml/utils/temporal.py
@@ -105,7 +105,6 @@ class TemporalDataProcessor:
             Temporal features [num_nodes, temporal_feature_dim]
         """
         num_nodes = timestamps.size(0)
-        feature_dim = features.size(1)
 
         # Sort nodes by timestamp
         sorted_indices = torch.argsort(timestamps)

--- a/astroml/validation/calibration.py
+++ b/astroml/validation/calibration.py
@@ -272,7 +272,7 @@ class CalibrationAnalyzer:
 
         # Color bins by sample count
         colors = plt.cm.YlOrRd(np.array(bin_counts) / max(bin_counts))
-        bars = ax3.bar(
+        ax3.bar(
             mean_pred,
             fraction_pos,
             width=1.0 / self.n_bins,


### PR DESCRIPTION
Closes #501

## Summary

- Removed unused imports, dead locals, and unreachable helper setup identified by Ruff/Vulture review.
- Marked required callback/context-manager parameters as intentionally unused without changing public call signatures.
- Kept cleanup scoped to unused-code removal and formatting of touched files.

## Validation

- `python -m ruff check astroml --select F401,F841 --exclude astroml/llm/labeling/consensus.py,astroml/models/deep_svdd_trainer.py`
- `python -m black --check <touched files>`
- `git diff --check`
- `python -m compileall -q <touched files>`
- `python -m pytest --noconftest tests/test_gat_attention.py -q` collected successfully; skipped locally due optional runtime dependency markers

## Notes

Full local repo-wide checks are still affected by upstream baseline syntax issues in `astroml/llm/labeling/consensus.py` and `astroml/models/deep_svdd_trainer.py`, so the focused lint command excludes those two files.
