### PR TITLE
feat(deployment): add automated rollback and disaster recovery manage…

### DIFF
--- a/astroml/deployment/disaster_recovery.py
+++ b/astroml/deployment/disaster_recovery.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import logging
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Callable, Dict, List, Literal, Optional
+
+from astroml.deployment.recovery_procedures import RecoveryProcedure
+from astroml.deployment.state_snapshot import Snapshot, StateSnapshotManager
+
+logger = logging.getLogger(__name__)
+
+RecoveryStatus = Literal["planned", "executing", "completed", "failed"]
+
+
+@dataclass
+class RecoveryPlan:
+    """A plan that binds a snapshot to a recovery procedure."""
+
+    plan_id: str
+    incident_id: str
+    snapshot_id: str
+    procedure_name: str
+    created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    status: str = "planned"
+    executed_at: datetime | None = None
+    result: dict[str, Any] = field(default_factory=dict)
+    last_error: str | None = None
+
+
+class DisasterRecoveryManager:
+    """Manages disaster recovery procedures and recovery testing."""
+
+    def __init__(self, snapshot_manager: StateSnapshotManager) -> None:
+        self._snapshot_manager = snapshot_manager
+        self._procedures: dict[str, RecoveryProcedure] = {}
+        self._plans: dict[str, RecoveryPlan] = {}
+
+    def register_procedure(self, procedure: RecoveryProcedure) -> None:
+        if procedure.name in self._procedures:
+            raise ValueError(f"Procedure '{procedure.name}' already registered")
+        self._procedures[procedure.name] = procedure
+        logger.info("Registered recovery procedure: %s", procedure.name)
+
+    def plan_recovery(self, incident_id: str, procedure_name: str, snapshot_id: str) -> RecoveryPlan:
+        if procedure_name not in self._procedures:
+            raise ValueError(f"Recovery procedure '{procedure_name}' not found")
+        self._snapshot_manager.get_snapshot(snapshot_id)
+
+        plan = RecoveryPlan(
+            plan_id=uuid.uuid4().hex,
+            incident_id=incident_id,
+            snapshot_id=snapshot_id,
+            procedure_name=procedure_name,
+        )
+        self._plans[plan.plan_id] = plan
+        return plan
+
+    def execute_recovery(
+        self,
+        plan_id: str,
+        apply_fn: Callable[[dict[str, Any]], bool] | None = None,
+    ) -> RecoveryPlan:
+        plan = self._plans.get(plan_id)
+        if plan is None:
+            raise ValueError(f"Recovery plan '{plan_id}' not found")
+        procedure = self._procedures.get(plan.procedure_name)
+        if procedure is None:
+            raise ValueError(f"Recovery procedure '{plan.procedure_name}' not found")
+
+        plan.status = "executing"
+        try:
+            snapshot = self._snapshot_manager.restore_snapshot(
+                plan.snapshot_id,
+                apply_fn=apply_fn,
+                restored_by="disaster-recovery",
+            )
+            plan.result["snapshot_restored"] = True
+            plan.result["snapshot_state"] = snapshot
+            plan.result["procedure"] = procedure.execute()
+            plan.status = "completed" if procedure.success else "failed"
+            plan.executed_at = datetime.now(timezone.utc)
+            if procedure.errors:
+                plan.last_error = "; ".join(procedure.errors)
+        except Exception as exc:
+            plan.status = "failed"
+            plan.executed_at = datetime.now(timezone.utc)
+            plan.last_error = str(exc)
+            plan.result["snapshot_restored"] = False
+            logger.exception("Recovery execution failed for plan %s", plan_id)
+
+        return plan
+
+    def test_recovery_scenario(
+        self,
+        plan_id: str,
+        validator: Callable[[Snapshot], bool],
+    ) -> dict[str, Any]:
+        plan = self._plans.get(plan_id)
+        if plan is None:
+            raise ValueError(f"Recovery plan '{plan_id}' not found")
+
+        snapshot = self._snapshot_manager.get_snapshot(plan.snapshot_id)
+        success = validator(snapshot)
+        return {
+            "plan_id": plan.plan_id,
+            "incident_id": plan.incident_id,
+            "snapshot_id": plan.snapshot_id,
+            "validator_passed": success,
+            "snapshot_available": snapshot is not None,
+            "snapshot_id": snapshot.snapshot_id,
+        }
+
+    def get_recovery_summary(self) -> dict[str, Any]:
+        statuses: dict[str, int] = {}
+        for plan in self._plans.values():
+            statuses[plan.status] = statuses.get(plan.status, 0) + 1
+        return {
+            "total_plans": len(self._plans),
+            "plans_by_status": statuses,
+            "registered_procedures": list(self._procedures.keys()),
+        }

--- a/astroml/deployment/recovery_procedures.py
+++ b/astroml/deployment/recovery_procedures.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Callable, Dict, List
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class RecoveryStep:
+    """A single step in a recovery procedure."""
+
+    name: str
+    description: str
+    action: Callable[[], bool]
+    completed: bool = False
+    result: str | None = None
+
+
+@dataclass
+class RecoveryProcedure:
+    """A sequence of steps used to recover from an incident."""
+
+    name: str
+    description: str
+    steps: list[RecoveryStep] = field(default_factory=list)
+    created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    completed_at: datetime | None = None
+    success: bool | None = None
+    errors: list[str] = field(default_factory=list)
+
+    def validate(self) -> None:
+        """Validate the procedure configuration before execution."""
+        if not self.steps:
+            raise ValueError("Recovery procedure must include at least one step")
+        names = [step.name for step in self.steps]
+        if len(names) != len(set(names)):
+            raise ValueError("Recovery procedure step names must be unique")
+
+    def execute(self) -> dict[str, Any]:
+        """Execute recovery steps in order."""
+        self.validate()
+        self.completed_at = None
+        self.success = True
+        self.errors.clear()
+
+        for step in self.steps:
+            try:
+                outcome = step.action()
+                step.completed = True
+                step.result = "success" if outcome else "failed"
+                if not outcome:
+                    self.success = False
+                    self.errors.append(f"Step failed: {step.name}")
+                    logger.warning("Recovery step failed: %s", step.name)
+                    break
+            except Exception as exc:
+                step.completed = False
+                step.result = str(exc)
+                self.success = False
+                self.errors.append(f"Step error: {step.name} - {exc}")
+                logger.exception("Recovery step error: %s", step.name)
+                break
+
+        self.completed_at = datetime.now(timezone.utc)
+        return {
+            "name": self.name,
+            "description": self.description,
+            "success": self.success,
+            "completed_at": self.completed_at.isoformat(),
+            "errors": self.errors.copy(),
+            "step_results": [
+                {
+                    "name": step.name,
+                    "completed": step.completed,
+                    "result": step.result,
+                }
+                for step in self.steps
+            ],
+        }

--- a/astroml/deployment/rollback_manager.py
+++ b/astroml/deployment/rollback_manager.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+import logging
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Callable, Dict, List, Literal, Optional
+
+from astroml.deployment.state_snapshot import StateSnapshotManager
+
+logger = logging.getLogger(__name__)
+
+RollbackStatus = Literal["requested", "approved", "executed", "cancelled", "failed"]
+RollbackSeverity = Literal["low", "medium", "high", "critical"]
+
+
+@dataclass
+class RollbackTrigger:
+    """Represents a rollback trigger event."""
+
+    reason: str
+    severity: RollbackSeverity
+    target_version: str
+    requested_by: str
+    created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    context: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class RollbackRecord:
+    """Tracks a requested or executed rollback."""
+
+    rollback_id: str
+    trigger: RollbackTrigger
+    status: RollbackStatus
+    snapshot_id: str | None = None
+    approved_by: str | None = None
+    approved_at: datetime | None = None
+    executed_at: datetime | None = None
+    error: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+class RollbackManager:
+    """Manages rollback requests, approval workflows, and recovery execution."""
+
+    AUTO_APPROVE_SEVERITIES: list[RollbackSeverity] = ["critical"]
+    VALID_SEVERITIES: list[RollbackSeverity] = ["low", "medium", "high", "critical"]
+
+    def __init__(self, snapshot_manager: StateSnapshotManager | None = None) -> None:
+        self._snapshot_manager = snapshot_manager
+        self._records: dict[str, RollbackRecord] = {}
+
+    def _generate_id(self) -> str:
+        return uuid.uuid4().hex
+
+    def trigger_rollback(
+        self,
+        reason: str,
+        target_version: str,
+        requested_by: str,
+        severity: RollbackSeverity = "medium",
+        snapshot_id: str | None = None,
+        context: dict[str, Any] | None = None,
+        auto_approve: bool = False,
+    ) -> RollbackRecord:
+        """Trigger a rollback request from monitored deployment telemetry."""
+        if severity not in self.VALID_SEVERITIES:
+            raise ValueError(f"Invalid rollback severity: {severity}")
+
+        trigger = RollbackTrigger(
+            reason=reason,
+            severity=severity,
+            target_version=target_version,
+            requested_by=requested_by,
+            context=context or {},
+        )
+        record = RollbackRecord(
+            rollback_id=self._generate_id(),
+            trigger=trigger,
+            status="approved" if auto_approve or severity in self.AUTO_APPROVE_SEVERITIES else "requested",
+            snapshot_id=snapshot_id,
+        )
+        self._records[record.rollback_id] = record
+
+        logger.info(
+            "Rollback triggered: id=%s target_version=%s severity=%s auto_approve=%s",
+            record.rollback_id,
+            target_version,
+            severity,
+            record.status == "approved",
+        )
+        return record
+
+    def request_approval(self, rollback_id: str, approver: str) -> RollbackRecord:
+        """Mark a rollback request as ready for approval."""
+        record = self._get_record(rollback_id)
+        if record.status != "requested":
+            raise ValueError("Rollback request is not in a pending state")
+
+        record.metadata["approval_requested_by"] = approver
+        record.metadata["approval_requested_at"] = datetime.now(timezone.utc).isoformat()
+        logger.info("Rollback approval requested: id=%s approver=%s", rollback_id, approver)
+        return record
+
+    def approve_rollback(self, rollback_id: str, approver: str) -> RollbackRecord:
+        """Approve a rollback request before execution."""
+        record = self._get_record(rollback_id)
+        if record.status != "requested" and record.status != "failed":
+            raise ValueError("Rollback request is not pending approval")
+
+        record.status = "approved"
+        record.approved_by = approver
+        record.approved_at = datetime.now(timezone.utc)
+        logger.info("Rollback approved: id=%s approver=%s", rollback_id, approver)
+        return record
+
+    def execute_rollback(
+        self,
+        rollback_id: str,
+        apply_fn: Callable[[dict[str, Any]], bool] | None = None,
+    ) -> RollbackRecord:
+        """Execute an approved rollback and optionally restore a state snapshot."""
+        record = self._get_record(rollback_id)
+        if record.status != "approved":
+            raise ValueError("Rollback request must be approved before execution")
+
+        try:
+            if record.snapshot_id:
+                if self._snapshot_manager is None:
+                    raise RuntimeError("Snapshot manager is required to restore state snapshots")
+                restored_state = self._snapshot_manager.restore_snapshot(
+                    record.snapshot_id,
+                    apply_fn=apply_fn,
+                    restored_by=record.trigger.requested_by,
+                )
+                record.metadata["restored_state"] = restored_state
+
+            record.status = "executed"
+            record.executed_at = datetime.now(timezone.utc)
+            logger.info("Rollback executed: id=%s target_version=%s", rollback_id, record.trigger.target_version)
+        except Exception as exc:
+            record.status = "failed"
+            record.error = str(exc)
+            record.executed_at = datetime.now(timezone.utc)
+            logger.exception("Rollback execution failed: id=%s error=%s", rollback_id, exc)
+        return record
+
+    def get_rollback(self, rollback_id: str) -> RollbackRecord:
+        return self._get_record(rollback_id)
+
+    def list_rollbacks(self) -> list[RollbackRecord]:
+        return list(self._records.values())
+
+    def get_dashboard(self) -> dict[str, Any]:
+        statuses: dict[str, int] = {}
+        for record in self._records.values():
+            statuses[record.status] = statuses.get(record.status, 0) + 1
+
+        latest = max(self._records.values(), key=lambda record: record.trigger.created_at, default=None)
+        dashboard = {
+            "total_rollbacks": len(self._records),
+            "rollbacks_by_status": statuses,
+            "latest_rollback": {
+                "rollback_id": latest.rollback_id,
+                "target_version": latest.trigger.target_version,
+                "status": latest.status,
+            }
+            if latest
+            else {},
+        }
+        return dashboard
+
+    def evaluate_health_metrics(
+        self,
+        failure_rate: float,
+        latency_ms: float,
+        error_budget: float = 0.1,
+        latency_threshold_ms: float = 2500.0,
+        **context: Any,
+    ) -> RollbackRecord | None:
+        """Evaluate deployment metrics to trigger an automated rollback."""
+        if failure_rate >= error_budget:
+            return self.trigger_rollback(
+                reason=f"Failure rate exceeded threshold: {failure_rate:.2%}",
+                target_version="unknown",
+                requested_by="system",
+                severity="critical",
+                snapshot_id=None,
+                context={"failure_rate": failure_rate, "latency_ms": latency_ms, **context},
+                auto_approve=True,
+            )
+
+        if latency_ms >= latency_threshold_ms:
+            return self.trigger_rollback(
+                reason=f"Latency exceeded threshold: {latency_ms:.2f}ms",
+                target_version="unknown",
+                requested_by="system",
+                severity="high",
+                snapshot_id=None,
+                context={"failure_rate": failure_rate, "latency_ms": latency_ms, **context},
+                auto_approve=False,
+            )
+
+        return None
+
+    def _get_record(self, rollback_id: str) -> RollbackRecord:
+        record = self._records.get(rollback_id)
+        if record is None:
+            raise ValueError(f"Rollback record '{rollback_id}' not found")
+        return record

--- a/astroml/deployment/state_snapshot.py
+++ b/astroml/deployment/state_snapshot.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional
+
+
+@dataclass
+class Snapshot:
+    """Represents a saved state snapshot for disaster recovery."""
+
+    snapshot_id: str
+    name: str
+    environment: str
+    model_version: str
+    state: dict[str, Any]
+    created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    recovery_objective_seconds: int = 300
+    restored_at: datetime | None = None
+    restored_by: str | None = None
+    recovery_metrics: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def within_objective(self) -> bool:
+        """Return True if the snapshot was restored within the RTO objective."""
+        if self.restored_at is None:
+            return False
+        elapsed = (self.restored_at - self.created_at).total_seconds()
+        return elapsed <= self.recovery_objective_seconds
+
+
+class StateSnapshotManager:
+    """Manages state snapshots and recovery operations."""
+
+    def __init__(self, storage_path: Path | str | None = None) -> None:
+        self._snapshots: dict[str, Snapshot] = {}
+        self._storage_path = Path(storage_path) if storage_path else None
+        if self._storage_path is not None:
+            self._storage_path.mkdir(parents=True, exist_ok=True)
+
+    def create_snapshot(
+        self,
+        name: str,
+        environment: str,
+        model_version: str,
+        state: dict[str, Any],
+        recovery_objective_seconds: int = 300,
+    ) -> Snapshot:
+        """Create and register a new state snapshot."""
+        if recovery_objective_seconds <= 0:
+            raise ValueError("recovery_objective_seconds must be positive")
+
+        snapshot_id = Path(name).stem + "-" + datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
+        snapshot = Snapshot(
+            snapshot_id=snapshot_id,
+            name=name,
+            environment=environment,
+            model_version=model_version,
+            state=state.copy(),
+            recovery_objective_seconds=recovery_objective_seconds,
+        )
+        self._snapshots[snapshot.snapshot_id] = snapshot
+        return snapshot
+
+    def get_snapshot(self, snapshot_id: str) -> Snapshot:
+        snapshot = self._snapshots.get(snapshot_id)
+        if snapshot is None:
+            raise ValueError(f"Snapshot '{snapshot_id}' not found")
+        return snapshot
+
+    def list_snapshots(self) -> list[Snapshot]:
+        return list(self._snapshots.values())
+
+    def restore_snapshot(
+        self,
+        snapshot_id: str,
+        apply_fn: Callable[[dict[str, Any]], bool] | None = None,
+        restored_by: str = "system",
+    ) -> dict[str, Any]:
+        """Restore a snapshot and record recovery metrics."""
+        snapshot = self.get_snapshot(snapshot_id)
+        if snapshot.restored_at is not None:
+            raise ValueError(f"Snapshot '{snapshot_id}' has already been restored")
+
+        snapshot.restored_at = datetime.now(timezone.utc)
+        snapshot.restored_by = restored_by
+        snapshot.recovery_metrics["rto_seconds"] = (snapshot.restored_at - snapshot.created_at).total_seconds()
+
+        if apply_fn is not None:
+            success = apply_fn(snapshot.state)
+            snapshot.recovery_metrics["applied_successfully"] = bool(success)
+            if not success:
+                raise RuntimeError(f"Snapshot '{snapshot_id}' failed to apply")
+
+        return snapshot.state.copy()
+
+    def cleanup_snapshot(self, snapshot_id: str) -> None:
+        """Delete a snapshot after recovery or archival."""
+        if snapshot_id not in self._snapshots:
+            raise ValueError(f"Snapshot '{snapshot_id}' not found")
+        del self._snapshots[snapshot_id]

--- a/docs/disaster-recovery.md
+++ b/docs/disaster-recovery.md
@@ -1,0 +1,103 @@
+# Disaster Recovery and Rollback
+
+## Overview
+
+AstroML now includes automated rollback and disaster recovery management for deployed models. The new deployment package supports:
+
+- Automated rollback triggers based on health, latency, or custom conditions.
+- State snapshot creation and restoration for recovery scenarios.
+- Structured recovery procedures with step validation.
+- Recovery plan execution and automated testing.
+- Rollback dashboards and recovery time objective (RTO) tracking.
+
+## Key components
+
+### `astroml.deployment.rollback_manager.RollbackManager`
+
+Use this manager to:
+
+- trigger rollback requests automatically or manually
+- request and approve rollback workflows
+- execute rollback actions using optional snapshot state restoration
+- inspect rollback dashboard summaries
+
+### `astroml.deployment.state_snapshot.StateSnapshotManager`
+
+This manager handles snapshot lifecycle:
+
+- creating snapshots with named state, environment, and version metadata
+- restoring snapshots and capturing RTO metrics
+- cleaning up snapshots after recovery
+
+### `astroml.deployment.recovery_procedures.RecoveryProcedure`
+
+Define recovery procedures as a sequence of atomic steps. Each step exposes:
+
+- a name and description
+- a callable action returning a boolean success indicator
+- execution results and error capture
+
+### `astroml.deployment.disaster_recovery.DisasterRecoveryManager`
+
+Use this manager to:
+
+- register recovery procedures
+- plan recovery workflows for specific incidents and snapshots
+- execute recovery plans with snapshot restoration and procedure orchestration
+- test recovery scenarios before they are executed in production
+
+## Example usage
+
+```python
+from astroml.deployment.rollback_manager import RollbackManager
+from astroml.deployment.state_snapshot import StateSnapshotManager
+from astroml.deployment.recovery_procedures import RecoveryProcedure, RecoveryStep
+from astroml.deployment.disaster_recovery import DisasterRecoveryManager
+
+snapshot_manager = StateSnapshotManager()
+rollback_manager = RollbackManager(snapshot_manager=snapshot_manager)
+
+snapshot = snapshot_manager.create_snapshot(
+    name="model-state-1",
+    environment="production",
+    model_version="1.2.0",
+    state={"route": "v1", "weights": "s3://..."},
+    recovery_objective_seconds=300,
+)
+
+rollback = rollback_manager.trigger_rollback(
+    reason="Deployment health degraded",
+    target_version="1.1.0",
+    requested_by="monitoring-system",
+    severity="critical",
+    snapshot_id=snapshot.snapshot_id,
+    auto_approve=True,
+)
+
+procedure = RecoveryProcedure(
+    name="basic-recovery",
+    description="Restore state and validate service availability",
+    steps=[
+        RecoveryStep(name="verify-snapshot", description="Ensure snapshot exists", action=lambda: True),
+        RecoveryStep(name="validate-dependencies", description="Confirm dependency health", action=lambda: True),
+    ],
+)
+
+recovery_manager = DisasterRecoveryManager(snapshot_manager)
+recovery_manager.register_procedure(procedure)
+plan = recovery_manager.plan_recovery(
+    incident_id="incident-123",
+    procedure_name="basic-recovery",
+    snapshot_id=snapshot.snapshot_id,
+)
+
+recovery_manager.execute_recovery(plan.plan_id)
+```
+
+## RTO Tracking
+
+Snapshots record `recovery_objective_seconds` and automatically compute whether a restore completed within the objective. Use `Snapshot.within_objective` to validate recovery time.
+
+## Testing recovery scenarios
+
+The `DisasterRecoveryManager.test_recovery_scenario` method helps validate an incident plan against a snapshot before executing the recovery in production.

--- a/tests/test_disaster_recovery.py
+++ b/tests/test_disaster_recovery.py
@@ -1,0 +1,114 @@
+"""Tests for disaster recovery planning and execution."""
+
+import pytest
+
+from astroml.deployment.disaster_recovery import DisasterRecoveryManager
+from astroml.deployment.recovery_procedures import RecoveryProcedure, RecoveryStep
+from astroml.deployment.state_snapshot import StateSnapshotManager
+
+
+def test_register_and_plan_recovery() -> None:
+    snapshot_manager = StateSnapshotManager()
+    snapshot = snapshot_manager.create_snapshot(
+        name="dr-snap",
+        environment="prod",
+        model_version="1.1.0",
+        state={"status": "ok"},
+    )
+
+    manager = DisasterRecoveryManager(snapshot_manager)
+    procedure = RecoveryProcedure(
+        name="restore-procedure",
+        description="Restore state",
+        steps=[RecoveryStep(name="step-1", description="noop", action=lambda: True)],
+    )
+    manager.register_procedure(procedure)
+
+    plan = manager.plan_recovery("incident-1", "restore-procedure", snapshot.snapshot_id)
+    assert plan.incident_id == "incident-1"
+    assert plan.snapshot_id == snapshot.snapshot_id
+    assert plan.status == "planned"
+
+
+def test_execute_recovery_plan_success() -> None:
+    snapshot_manager = StateSnapshotManager()
+    snapshot = snapshot_manager.create_snapshot(
+        name="dr-snap-2",
+        environment="prod",
+        model_version="1.1.1",
+        state={"feature_flag": True},
+    )
+
+    manager = DisasterRecoveryManager(snapshot_manager)
+    procedure = RecoveryProcedure(
+        name="restore-procedure-2",
+        description="Restore state",
+        steps=[RecoveryStep(name="step-1", description="noop", action=lambda: True)],
+    )
+    manager.register_procedure(procedure)
+    plan = manager.plan_recovery("incident-2", "restore-procedure-2", snapshot.snapshot_id)
+
+    executed = manager.execute_recovery(plan.plan_id, apply_fn=lambda state: state["feature_flag"] is True)
+    assert executed.status == "completed"
+    assert executed.result["snapshot_restored"] is True
+    assert executed.result["procedure"]["success"] is True
+
+
+def test_execute_recovery_plan_fails_when_snapshot_missing() -> None:
+    snapshot_manager = StateSnapshotManager()
+    manager = DisasterRecoveryManager(snapshot_manager)
+    procedure = RecoveryProcedure(
+        name="restore-procedure-3",
+        description="Restore state",
+        steps=[RecoveryStep(name="step-1", description="noop", action=lambda: True)],
+    )
+    manager.register_procedure(procedure)
+
+    with pytest.raises(ValueError, match="Snapshot 'nonexistent' not found"):
+        manager.plan_recovery("incident-3", "restore-procedure-3", "nonexistent")
+
+
+def test_test_recovery_scenario_validator() -> None:
+    snapshot_manager = StateSnapshotManager()
+    snapshot = snapshot_manager.create_snapshot(
+        name="dr-snap-4",
+        environment="prod",
+        model_version="1.1.2",
+        state={"enabled": True},
+    )
+
+    manager = DisasterRecoveryManager(snapshot_manager)
+    procedure = RecoveryProcedure(
+        name="restore-procedure-4",
+        description="Restore state",
+        steps=[RecoveryStep(name="step-1", description="noop", action=lambda: True)],
+    )
+    manager.register_procedure(procedure)
+    plan = manager.plan_recovery("incident-4", "restore-procedure-4", snapshot.snapshot_id)
+
+    result = manager.test_recovery_scenario(plan.plan_id, validator=lambda s: s.environment == "prod")
+    assert result["validator_passed"] is True
+    assert result["snapshot_available"] is True
+
+
+def test_get_recovery_summary_counts() -> None:
+    snapshot_manager = StateSnapshotManager()
+    snapshot = snapshot_manager.create_snapshot(
+        name="dr-snap-5",
+        environment="prod",
+        model_version="1.1.3",
+        state={"enabled": True},
+    )
+
+    manager = DisasterRecoveryManager(snapshot_manager)
+    procedure = RecoveryProcedure(
+        name="restore-procedure-5",
+        description="Restore state",
+        steps=[RecoveryStep(name="step-1", description="noop", action=lambda: True)],
+    )
+    manager.register_procedure(procedure)
+    manager.plan_recovery("incident-5", "restore-procedure-5", snapshot.snapshot_id)
+
+    summary = manager.get_recovery_summary()
+    assert summary["total_plans"] == 1
+    assert summary["registered_procedures"] == ["restore-procedure-5"]

--- a/tests/test_recovery_procedures.py
+++ b/tests/test_recovery_procedures.py
@@ -1,0 +1,73 @@
+"""Tests for recovery procedures and step execution."""
+
+import pytest
+
+from astroml.deployment.recovery_procedures import RecoveryProcedure, RecoveryStep
+
+
+def test_recovery_procedure_validate_no_steps() -> None:
+    procedure = RecoveryProcedure(name="empty", description="No steps")
+    with pytest.raises(ValueError, match="must include at least one step"):
+        procedure.execute()
+
+
+def test_recovery_procedure_validate_duplicate_names() -> None:
+    procedure = RecoveryProcedure(
+        name="duplicate",
+        description="Duplicates",
+        steps=[
+            RecoveryStep(name="step1", description="first", action=lambda: True),
+            RecoveryStep(name="step1", description="duplicate", action=lambda: True),
+        ],
+    )
+    with pytest.raises(ValueError, match="step names must be unique"):
+        procedure.execute()
+
+
+def test_recovery_procedure_execute_success() -> None:
+    procedure = RecoveryProcedure(
+        name="success",
+        description="All pass",
+        steps=[
+            RecoveryStep(name="check-1", description="A", action=lambda: True),
+            RecoveryStep(name="check-2", description="B", action=lambda: True),
+        ],
+    )
+    result = procedure.execute()
+
+    assert result["success"] is True
+    assert result["errors"] == []
+    assert result["step_results"][0]["result"] == "success"
+    assert result["step_results"][1]["result"] == "success"
+
+
+def test_recovery_procedure_execute_failure_on_step() -> None:
+    procedure = RecoveryProcedure(
+        name="partial",
+        description="One fails",
+        steps=[
+            RecoveryStep(name="check-1", description="A", action=lambda: True),
+            RecoveryStep(name="check-2", description="B", action=lambda: False),
+            RecoveryStep(name="check-3", description="C", action=lambda: True),
+        ],
+    )
+    result = procedure.execute()
+
+    assert result["success"] is False
+    assert any("Step failed" in error for error in result["errors"])
+    assert result["step_results"][2]["completed"] is False
+
+
+def test_recovery_procedure_step_exception() -> None:
+    def bad_action() -> bool:
+        raise RuntimeError("unexpected")
+
+    procedure = RecoveryProcedure(
+        name="exception",
+        description="Raises",
+        steps=[RecoveryStep(name="check", description="Fail", action=bad_action)],
+    )
+    result = procedure.execute()
+
+    assert result["success"] is False
+    assert any("Step error" in error for error in result["errors"])

--- a/tests/test_rollback_manager.py
+++ b/tests/test_rollback_manager.py
@@ -1,0 +1,119 @@
+"""Tests for rollback management and triggers."""
+
+from astroml.deployment.rollback_manager import RollbackManager
+from astroml.deployment.state_snapshot import StateSnapshotManager
+
+
+def test_trigger_rollback_request() -> None:
+    manager = RollbackManager()
+    record = manager.trigger_rollback(
+        reason="Degraded performance",
+        target_version="1.0.0",
+        requested_by="monitoring",
+        severity="high",
+        snapshot_id="snap-1",
+    )
+
+    assert record.status == "requested"
+    assert record.trigger.severity == "high"
+    assert record.snapshot_id == "snap-1"
+
+
+def test_trigger_rollback_auto_approve_for_critical() -> None:
+    manager = RollbackManager()
+    record = manager.trigger_rollback(
+        reason="Critical failure",
+        target_version="1.0.0",
+        requested_by="system",
+        severity="critical",
+    )
+
+    assert record.status == "approved"
+    assert record.trigger.requested_by == "system"
+
+
+def test_request_and_approve_rollback() -> None:
+    manager = RollbackManager()
+    record = manager.trigger_rollback(
+        reason="High latency",
+        target_version="1.0.0",
+        requested_by="monitor",
+        severity="medium",
+    )
+
+    manager.request_approval(record.rollback_id, approver="lead")
+    approved = manager.approve_rollback(record.rollback_id, approver="lead")
+
+    assert approved.status == "approved"
+    assert approved.approved_by == "lead"
+
+
+def test_execute_rollback_restores_snapshot() -> None:
+    snapshot_manager = StateSnapshotManager()
+    snapshot = snapshot_manager.create_snapshot(
+        name="rollback-snap",
+        environment="prod",
+        model_version="1.0.1",
+        state={"route": "v2"},
+    )
+    manager = RollbackManager(snapshot_manager=snapshot_manager)
+    record = manager.trigger_rollback(
+        reason="Service regression",
+        target_version="1.0.0",
+        requested_by="ops",
+        severity="critical",
+        snapshot_id=snapshot.snapshot_id,
+        auto_approve=True,
+    )
+
+    result = manager.execute_rollback(record.rollback_id, apply_fn=lambda state: state["route"] == "v2")
+    assert result.status == "executed"
+    assert result.metadata["restored_state"] == {"route": "v2"}
+
+
+def test_execute_rollback_fails_without_approval() -> None:
+    manager = RollbackManager()
+    record = manager.trigger_rollback(
+        reason="Latency alert",
+        target_version="1.0.2",
+        requested_by="monitor",
+        severity="high",
+        auto_approve=False,
+    )
+
+    try:
+        manager.execute_rollback(record.rollback_id)
+    except ValueError as exc:
+        assert "must be approved" in str(exc)
+    else:
+        assert False, "execute_rollback should raise ValueError for unapproved request"
+
+
+def test_evaluate_health_metrics_triggers_critical_auto_approval() -> None:
+    manager = RollbackManager()
+    record = manager.evaluate_health_metrics(failure_rate=0.2, latency_ms=2000.0)
+
+    assert record is not None
+    assert record.status == "approved"
+    assert record.trigger.severity == "critical"
+
+
+def test_get_dashboard_counts() -> None:
+    manager = RollbackManager()
+    manager.trigger_rollback(
+        reason="Minor issue",
+        target_version="1.0.0",
+        requested_by="sys",
+        severity="low",
+    )
+    manager.trigger_rollback(
+        reason="Critical outage",
+        target_version="1.0.0",
+        requested_by="sys",
+        severity="critical",
+    )
+
+    dashboard = manager.get_dashboard()
+    assert dashboard["total_rollbacks"] == 2
+    assert dashboard["rollbacks_by_status"]["requested"] == 1
+    assert dashboard["rollbacks_by_status"]["approved"] == 1

--- a/tests/test_state_snapshot.py
+++ b/tests/test_state_snapshot.py
@@ -1,0 +1,88 @@
+"""Tests for state snapshot recovery management."""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from astroml.deployment.state_snapshot import Snapshot, StateSnapshotManager
+
+
+def test_create_and_get_snapshot() -> None:
+    manager = StateSnapshotManager()
+    snapshot = manager.create_snapshot(
+        name="model-state",
+        environment="production",
+        model_version="1.0.0",
+        state={"route": "v1"},
+        recovery_objective_seconds=60,
+    )
+
+    assert snapshot.name == "model-state"
+    assert snapshot.environment == "production"
+    assert snapshot.model_version == "1.0.0"
+    assert snapshot.within_objective is False
+
+    loaded = manager.get_snapshot(snapshot.snapshot_id)
+    assert loaded.snapshot_id == snapshot.snapshot_id
+
+
+def test_restore_snapshot_applies_state() -> None:
+    manager = StateSnapshotManager()
+    snapshot = manager.create_snapshot(
+        name="snapshot-restore",
+        environment="staging",
+        model_version="2.0.0",
+        state={"config": "ok"},
+        recovery_objective_seconds=300,
+    )
+
+    def apply_fn(state: dict[str, object]) -> bool:
+        assert state == {"config": "ok"}
+        return True
+
+    restored = manager.restore_snapshot(snapshot.snapshot_id, apply_fn=apply_fn, restored_by="tester")
+    assert restored == {"config": "ok"}
+    assert snapshot.restored_by == "tester"
+    assert snapshot.recovery_metrics["applied_successfully"] is True
+    assert snapshot.within_objective is True
+
+
+def test_restore_snapshot_fails_when_already_restored() -> None:
+    manager = StateSnapshotManager()
+    snapshot = manager.create_snapshot(
+        name="snapshot-single",
+        environment="test",
+        model_version="0.0.1",
+        state={"x": 1},
+        recovery_objective_seconds=1,
+    )
+
+    manager.restore_snapshot(snapshot.snapshot_id)
+    with pytest.raises(ValueError, match="already been restored"):
+        manager.restore_snapshot(snapshot.snapshot_id)
+
+
+def test_cleanup_snapshot_removes_snapshot() -> None:
+    manager = StateSnapshotManager()
+    snapshot = manager.create_snapshot(
+        name="snapshot-cleanup",
+        environment="dev",
+        model_version="0.9.0",
+        state={"flag": True},
+    )
+
+    manager.cleanup_snapshot(snapshot.snapshot_id)
+    with pytest.raises(ValueError, match="Snapshot 'snapshot-cleanup"):
+        manager.get_snapshot(snapshot.snapshot_id)
+
+
+def test_create_snapshot_invalid_rto() -> None:
+    manager = StateSnapshotManager()
+    with pytest.raises(ValueError, match="recovery_objective_seconds must be positive"):
+        manager.create_snapshot(
+            name="invalid",
+            environment="dev",
+            model_version="1.0.0",
+            state={"x": 1},
+            recovery_objective_seconds=0,
+        )


### PR DESCRIPTION
## Summary

This PR implements an automated rollback and disaster recovery framework for model deployments to improve system reliability and minimize downtime during deployment failures. It introduces state snapshot management, rollback orchestration, recovery procedures, and supporting documentation.

## Changes

* Added automated rollback triggers for failed model deployments.
* Implemented state snapshot creation and management to enable safe rollback operations.
* Added disaster recovery procedures for restoring deployments from snapshots.
* Introduced recovery testing automation to validate rollback and recovery workflows.
* Added rollback approval workflow support for controlled recovery operations.
* Implemented Recovery Time Objective (RTO) tracking to monitor recovery performance.
* Updated disaster recovery documentation with recovery procedures and operational guidance.

## Testing

* Added unit tests covering rollback, snapshot management, and recovery workflows.
* Simulated deployment failures to verify automated rollback behavior.
* Validated disaster recovery scenarios and state restoration.
* Confirmed all tests pass with `pytest tests/`.
* Verified linting passes with `pre-commit run --all-files`.

## Documentation

* Added and updated `docs/disaster-recovery.md` with rollback procedures, recovery workflow, and operational best practices.

## Related Issue

Closes #651
Closes #650 
Closes #649 
Closes #648
